### PR TITLE
Fix copy/paste error (8-bit width, not 16-bit)

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -192,7 +192,7 @@ wire [63:0] img_size;
 wire        forced_scandoubler;
 
 
-hps_io #(.STRLEN(($size(CONF_STR1)>>3) + ($size(CONF_STR2)>>3) + ($size(CONF_STR3)>>3) + ($size(CONF_STR4)>>3) + 3), .WIDE(1)) hps_io
+hps_io #(.STRLEN(($size(CONF_STR1)>>3) + ($size(CONF_STR2)>>3) + ($size(CONF_STR3)>>3) + ($size(CONF_STR4)>>3) + 3), .WIDE(0)) hps_io
 (
 	.clk_sys(clk_sys),
 	.HPS_BUS(HPS_BUS),


### PR DESCRIPTION
The HPS interface for this core is 8-bit, not 16-bit.