### PR TITLE
VDPTest compliance and extended modes

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -134,9 +134,9 @@ assign {UART_RTS, UART_TXD, UART_DTR} = 0;
 assign {SD_SCK, SD_MOSI, SD_CS} = '1;
 assign {DDRAM_CLK, DDRAM_BURSTCNT, DDRAM_ADDR, DDRAM_DIN, DDRAM_BE, DDRAM_RD, DDRAM_WE} = '0;
 
-assign LED_USER  = ioctl_download | bk_state;
-assign LED_DISK  = 0;
-assign LED_POWER = 0;
+assign LED_USER  = ioctl_download | bk_state | smode_M1 ;
+assign LED_DISK  = smode_M1 ? 2'b11 : 2'b10 ;
+assign LED_POWER = smode_M3 ? 2'b11 : 2'b10 ;
 
 assign VIDEO_ARX = status[9] ? 8'd16 : 8'd4;
 assign VIDEO_ARY = status[9] ? 8'd9  : 8'd3;
@@ -367,6 +367,8 @@ system #(MAX_SPPL) system
 	.y(y),
 	.color(color),
 	.mask_column(mask_column),
+	.smode_M1(smode_M1),
+	.smode_M3(smode_M3),
 
 	.fm_ena(~status[12]),
 	.audioL(audio_l),
@@ -473,16 +475,17 @@ always @(negedge clk_sys) begin
 		clkd <= 0;
 		ce_vdp <= 1;
 		ce_pix <= 1;
-		ce_cpu <= 1;
 	end else if (clkd==24) begin
+		ce_cpu <= 1;  //-- changed cpu phase to please VDPTEST HCounter test;
+						  // not that I think that it does any good. Flynn.
 		ce_vdp <= 1;
 	end else if (clkd==19) begin
 		ce_vdp <= 1;
 		ce_pix <= 1;
 	end else if (clkd==14) begin
 		ce_vdp <= 1;
-		ce_cpu <= 1;
 	end else if (clkd==9) begin
+		ce_cpu <= 1;
 		ce_vdp <= 1;
 		ce_pix <= 1;
 	end else if (clkd==4) begin

--- a/SMS.sv
+++ b/SMS.sv
@@ -435,6 +435,7 @@ wire [8:0] x;
 wire [8:0] y;
 wire [11:0] color;
 wire mask_column;
+wire smode_M1, smode_M3;
 wire pal = status[2];
 
 video video
@@ -445,7 +446,8 @@ video video
 	.gg(gg),
 	.border(status[13]),
 	.mask_column(mask_column),
-
+   .smode_M1(smode_M1),
+	.smode_M3(smode_M3),
 	.x(x),
 	.y(y),
 

--- a/SMS.sv
+++ b/SMS.sv
@@ -452,7 +452,6 @@ video video
 	.smode_M3(smode_M3),
 	.x(x),
 	.y(y),
-
 	.hsync(HSync),
 	.vsync(VSync),
 	.hblank(HBlank),
@@ -477,7 +476,6 @@ always @(negedge clk_sys) begin
 		ce_pix <= 1;
 	end else if (clkd==24) begin
 		ce_cpu <= 1;  //-- changed cpu phase to please VDPTEST HCounter test;
-						  // not that I think that it does any good. Flynn.
 		ce_vdp <= 1;
 	end else if (clkd==19) begin
 		ce_vdp <= 1;

--- a/SMS.sv
+++ b/SMS.sv
@@ -135,8 +135,8 @@ assign {SD_SCK, SD_MOSI, SD_CS} = '1;
 assign {DDRAM_CLK, DDRAM_BURSTCNT, DDRAM_ADDR, DDRAM_DIN, DDRAM_BE, DDRAM_RD, DDRAM_WE} = '0;
 
 assign LED_USER  = ioctl_download | bk_state ;
-assign LED_DISK  = smode_M1 ? 2'b11 : 2'b10 ;
-assign LED_POWER = smode_M3 ? 2'b11 : 2'b10 ;
+assign LED_DISK  = 0 ; // smode_M1 ? 2'b11 : 2'b10 ;
+assign LED_POWER = 0 ; // smode_M3 ? 2'b11 : 2'b10 ;
 
 assign VIDEO_ARX = status[9] ? 8'd16 : 8'd4;
 assign VIDEO_ARY = status[9] ? 8'd9  : 8'd3;

--- a/SMS.sv
+++ b/SMS.sv
@@ -134,7 +134,7 @@ assign {UART_RTS, UART_TXD, UART_DTR} = 0;
 assign {SD_SCK, SD_MOSI, SD_CS} = '1;
 assign {DDRAM_CLK, DDRAM_BURSTCNT, DDRAM_ADDR, DDRAM_DIN, DDRAM_BE, DDRAM_RD, DDRAM_WE} = '0;
 
-assign LED_USER  = ioctl_download | bk_state | smode_M1 ;
+assign LED_USER  = ioctl_download | bk_state ;
 assign LED_DISK  = smode_M1 ? 2'b11 : 2'b10 ;
 assign LED_POWER = smode_M3 ? 2'b11 : 2'b10 ;
 

--- a/build_id.v
+++ b/build_id.v
@@ -1,0 +1,2 @@
+`define BUILD_DATE "190402"
+`define BUILD_TIME "030128"

--- a/build_id.v
+++ b/build_id.v
@@ -1,2 +1,0 @@
-`define BUILD_DATE "190402"
-`define BUILD_TIME "030128"

--- a/mist/SMS.sv
+++ b/mist/SMS.sv
@@ -281,6 +281,8 @@ system #(MAX_SPPL) system
 	.x(x),
 	.y(y),
 	.color(color),
+	.smode_M1(smode_M1),
+	.smode_M3(smode_M3),	
 	.fm_ena(~status[12]),  
 	.audioL(audioL),
     .audioR(audioR),
@@ -311,6 +313,7 @@ wire [8:0] x;
 wire [8:0] y;
 wire [11:0] color;
 wire HSync, VSync, HBlank, VBlank;
+wire smode_M1, smode_M3;
 
 video video
 (
@@ -321,7 +324,9 @@ video video
 	.border(1),
 	.x(x),
 	.y(y),
-
+   .smode_M1(smode_M1),
+	.smode_M3(smode_M3),
+	
 	.hsync(HSync),
 	.vsync(VSync),
 	.hblank(HBlank),
@@ -346,24 +351,24 @@ always @(negedge clk_sys) begin
 		clkd <= 0;
 		ce_vdp <= 1;
 		ce_pix <= 1;
-		ce_cpu_p <= 1;
 	end else if (clkd==24) begin
 		ce_vdp <= 1;
-	end else if (clkd==22) begin
-		ce_cpu_n <= 1;
+		ce_cpu_p <= 1;
 	end else if (clkd==19) begin
 		ce_vdp <= 1;
 		ce_pix <= 1;
+	end else if (clkd==17) begin
+		ce_cpu_n <= 1;
 	end else if (clkd==14) begin
 		ce_vdp <= 1;
-		ce_cpu_p <= 1;
 	end else if (clkd==9) begin
+		ce_cpu_p <= 1;
 		ce_vdp <= 1;
 		ce_pix <= 1;
-	end else if (clkd==7) begin
-		ce_cpu_n <= 1;
 	end else if (clkd==4) begin
 		ce_vdp <= 1;
+	end else if (clkd==2) begin
+		ce_cpu_n <= 1;
 	end
 end
 

--- a/system.vhd
+++ b/system.vhd
@@ -343,7 +343,16 @@ begin
 						when "11" => bank2 <= D_in;
 					end case;
 				end if;
-
+				-- Codemasters
+				if WR_n='0' and A(15 downto 0)=x"0000" then
+					bank0 <= D_in;
+				end if;
+				if WR_n='0' and A(15 downto 0)=x"4000" then
+					bank1 <= D_in;
+				end if;
+				if WR_n='0' and A(15 downto 0)=x"8000" then
+					bank2 <= D_in;
+				end if;
 				-- Korean mapper (Sangokushi 3, Dodgeball King)
 				-- should be safe to enable unconditionally, A000 is ROM area
 				if WR_n='0' and A(15 downto 0)=x"A000" then

--- a/system.vhd
+++ b/system.vhd
@@ -42,6 +42,8 @@ entity system is
 		y:				in	 STD_LOGIC_VECTOR(8 downto 0);
 		color:		out STD_LOGIC_VECTOR(11 downto 0);
 		mask_column:out STD_LOGIC;
+		smode_M1:		out STD_LOGIC;
+		smode_M3:		out STD_LOGIC;
 
 		audioL:		out STD_LOGIC_VECTOR(15 downto 0);
 		audioR:		out STD_LOGIC_VECTOR(15 downto 0);
@@ -165,6 +167,8 @@ begin
 		x			=> x,
 		y			=> y,
 		color		=> color,
+		smode_M1  => smode_M1,
+		smode_M3  => smode_M3,
 		mask_column => mask_column,
 		reset_n  => RESET_n
 	);

--- a/system.vhd
+++ b/system.vhd
@@ -343,20 +343,17 @@ begin
 						when "11" => bank2 <= D_in;
 					end case;
 				end if;
+				if WR_n='0' and nvram_e='0' then
+					case A(15 downto 0) is
 				-- Codemasters
-				if WR_n='0' and A(15 downto 0)=x"0000" then
-					bank0 <= D_in;
-				end if;
-				if WR_n='0' and A(15 downto 0)=x"4000" then
-					bank1 <= D_in;
-				end if;
-				if WR_n='0' and A(15 downto 0)=x"8000" then
-					bank2 <= D_in;
-				end if;
+						when x"0000" => bank0 <= D_in ;
+						when x"4000" => bank1 <= D_in ;
+						when x"8000" => bank2 <= D_in ;
 				-- Korean mapper (Sangokushi 3, Dodgeball King)
 				-- should be safe to enable unconditionally, A000 is ROM area
-				if WR_n='0' and A(15 downto 0)=x"A000" then
-					bank2 <= D_in;
+						when x"A000" => bank2 <= D_in ;
+						when others => null ;
+					end case ;
 				end if;
 			end if;
 		end if;

--- a/vdp.vhd
+++ b/vdp.vhd
@@ -26,8 +26,8 @@ entity vdp is
 		y:					in  STD_LOGIC_VECTOR (8 downto 0);
 		color:			out STD_LOGIC_VECTOR (11 downto 0);
 		mask_column:   out STD_LOGIC;
-		smode_M1: 		buffer STD_LOGIC;
-		smode_M3: 		buffer STD_LOGIC;
+		smode_M1: 		out STD_LOGIC;
+		smode_M3: 		out STD_LOGIC;
 		reset_n:       in  STD_LOGIC);
 end vdp;
 
@@ -94,10 +94,14 @@ architecture Behavioral of vdp is
 	signal mode_M1:			std_logic;
 	signal mode_M2:			std_logic;
 	signal mode_M3:			std_logic;
+	signal xmode_M1:			std_logic;
+	signal xmode_M3:			std_logic;
 	
 begin
 	
 	mask_column <= mask_column0;
+	xmode_M1<= mode_M1 and mode_M2 ;
+	xmode_M3<= mode_M3 and mode_M2 ;
 
 	vdp_main_inst: entity work.vdp_main
 	generic map(
@@ -118,8 +122,8 @@ begin
 		x					=> x,
 		y					=> y,
 		color				=> color,
-		smode_M1			=> smode_M1,
-		smode_M3			=> smode_M3,
+		smode_M1			=> xmode_M1,
+		smode_M3			=> xmode_M3,
 						
 		display_on		=> display_on,
 		mask_column0	=> mask_column0,
@@ -314,7 +318,7 @@ begin
 		if rising_edge(clk_sys) then
 			if ce_vdp = '1' then
 				if x=487 and 
-					((y=224 and smode_M1='1') or (y=240 and smode_M3='1') or (y=192 and smode_M1='0' and smode_M3='0')) 
+					((y=224 and xmode_M1='1') or (y=240 and xmode_M3='1') or (y=192 and xmode_M1='0' and xmode_M3='0')) 
 					and not (last_x0=std_logic(x(0))) then
 					vbl_irq <= '1';
 				elsif reset_flags then
@@ -330,7 +334,7 @@ begin
 			if ce_vdp = '1' then
 				last_x0 <= std_logic(x(0));
 				if x=487 and not (last_x0=std_logic(x(0))) then
-					if y<192 or (y<240 and smode_M3='1') or (y<224 and smode_M1='1') or y=511 then
+					if y<192 or (y<240 and xmode_M3='1') or (y<224 and xmode_M1='1') or y=511 then
 						if hbl_counter=0 then
 							hbl_irq <= hbl_irq or irq_line_en; -- <=> if irq_line_en then hbl_irq<=1
 							hbl_counter <= irq_line_count;

--- a/vdp.vhd
+++ b/vdp.vhd
@@ -71,7 +71,7 @@ architecture Behavioral of vdp is
 	signal irq_frame_en:		std_logic := '0';
 	signal irq_line_en:		std_logic := '0';
 	signal irq_line_count:	std_logic_vector(7 downto 0) := (others=>'1');	
-	signal bg_address:		std_logic_vector (3 downto 0) := (others=>'0');
+	signal bg_address:		std_logic_vector (2 downto 0) := (others=>'0');
 	signal bg_scroll_x:		std_logic_vector(7 downto 0) := (others=>'0');
 	signal bg_scroll_y:		std_logic_vector(7 downto 0) := (others=>'0');
 	signal spr_address:		std_logic_vector (5 downto 0) := (others=>'0');
@@ -194,7 +194,7 @@ begin
 			display_on		<= '0';--80
 			irq_frame_en	<= '0';--
 			spr_tall			<= '0';--
-			bg_address		<= "1111";--FF
+			bg_address		<= "111";--FF
 			spr_address		<= "111111";--FF
 			spr_high_bit	<= '0';--FB
 			overscan			<= "0000";--00
@@ -254,7 +254,7 @@ begin
 								mode_M3			<= xram_cpu_A(3) and not xram_cpu_A(4);
 								spr_tall			<= xram_cpu_A(1);
 							when "100010" =>
-								bg_address		<= xram_cpu_A(3 downto 0);
+								bg_address		<= xram_cpu_A(3 downto 1);
 							when "100101" =>
 								spr_address		<= xram_cpu_A(6 downto 1);
 							when "100110" =>

--- a/vdp.vhd
+++ b/vdp.vhd
@@ -317,7 +317,8 @@ begin
 	begin
 		if rising_edge(clk_sys) then
 			if ce_vdp = '1' then
-				if x=487 and 
+--				485 instead of 487 to please VDPTEST - Flynn
+				if x=485 and
 					((y=224 and xmode_M1='1') or (y=240 and xmode_M3='1') or (y=192 and xmode_M1='0' and xmode_M3='0')) 
 					and not (last_x0=std_logic(x(0))) then
 					vbl_irq <= '1';

--- a/vdp_background.vhd
+++ b/vdp_background.vhd
@@ -8,9 +8,11 @@ port (
 	clk_sys:				in  STD_LOGIC;
 	ce_pix:				in  STD_LOGIC;
 	reset:				in  std_logic;
-	table_address:		in  std_logic_vector(13 downto 11);
+	table_address:		in  std_logic_vector(13 downto 10);
 	scroll_x:			in  std_logic_vector(7 downto 0);
 	disable_hscroll:	in  std_logic;
+	smode_M1:			in  std_logic;
+	smode_M3:			in  std_logic;
 	y:						in  std_logic_vector(7 downto 0);
 	screen_y:				in  std_logic_vector(8 downto 0);
 
@@ -65,8 +67,14 @@ begin
 	begin
 		if rising_edge(clk_sys) then
 			if ce_pix = '1' then
-				char_address(12 downto 10)	:= table_address;
-				char_address(9 downto 5)	:= y(7 downto 3);
+			   if (smode_M1='1' or smode_M3='1') then
+					char_address(12 downto 5) := table_address(13 downto 12) & ("011100" + y(7 downto 3));
+					-- bug SMS_CONSOLE
+					-- if (table_address(10)='0') then char_address(9):='0' ; end if ;
+				else
+					char_address(12 downto 10)	:= table_address(13 downto 11);
+					char_address(9 downto 5)	:= y(7 downto 3);
+				end if;
 				char_address(4 downto 0)	:= x(7 downto 3) + 1;
 				data_address					:= tile_index & tile_y;
 				

--- a/vdp_background.vhd
+++ b/vdp_background.vhd
@@ -14,7 +14,7 @@ port (
 	smode_M1:			in  std_logic;
 	smode_M3:			in  std_logic;
 	y:						in  std_logic_vector(7 downto 0);
-	screen_y:				in  std_logic_vector(8 downto 0);
+	screen_y:			in  std_logic_vector(8 downto 0);
 
 	vram_A:				out std_logic_vector(13 downto 0);
 	vram_D:				in  std_logic_vector(7 downto 0);
@@ -50,9 +50,9 @@ begin
 			if ce_pix = '1' then
 				if (reset='1') then
 					if disable_hscroll='0' or screen_y>=16 then
-						x <= 240-scroll_x+1; -- temporary workaround of 1pix roll - needs better fix!
+						x <= 230-scroll_x+1; -- temporary workaround of 1pix roll - needs better fix!
 					else
-						x <= "11110001"; -- 241
+						x <= "11100111"; -- 231
 					end if;
 				else
 					x <= x + 1;

--- a/vdp_background.vhd
+++ b/vdp_background.vhd
@@ -8,7 +8,7 @@ port (
 	clk_sys:				in  STD_LOGIC;
 	ce_pix:				in  STD_LOGIC;
 	reset:				in  std_logic;
-	table_address:		in  std_logic_vector(13 downto 10);
+	table_address:		in  std_logic_vector(13 downto 11);
 	scroll_x:			in  std_logic_vector(7 downto 0);
 	disable_hscroll:	in  std_logic;
 	smode_M1:			in  std_logic;
@@ -69,8 +69,6 @@ begin
 			if ce_pix = '1' then
 			   if (smode_M1='1' or smode_M3='1') then
 					char_address(12 downto 5) := table_address(13 downto 12) & ("011100" + y(7 downto 3));
-					-- bug SMS_CONSOLE
-					-- if (table_address(10)='0') then char_address(9):='0' ; end if ;
 				else
 					char_address(12 downto 10)	:= table_address(13 downto 11);
 					char_address(9 downto 5)	:= y(7 downto 3);

--- a/vdp_main.vhd
+++ b/vdp_main.vhd
@@ -30,7 +30,7 @@ entity vdp_main is
 		smode_M3:			in  std_logic;
 		overscan:			in  std_logic_vector (3 downto 0);
 
-		bg_address:			in  std_logic_vector (3 downto 0);
+		bg_address:			in  std_logic_vector (2 downto 0);
 		bg_scroll_x:		in  std_logic_vector(7 downto 0);
 		bg_scroll_y:		in  std_logic_vector(7 downto 0);
 		disable_hscroll:	in  std_logic;

--- a/vdp_main.vhd
+++ b/vdp_main.vhd
@@ -58,7 +58,7 @@ architecture Behavioral of vdp_main is
 
 begin
 
-	process (x,y,bg_scroll_y,disable_vscroll)
+	process (x,y,bg_scroll_y,disable_vscroll,smode_M1,smode_M3)
 		variable sum: std_logic_vector(8 downto 0);
 	begin
 		if disable_vscroll = '0' or x+16 < 25*8 then
@@ -119,7 +119,7 @@ begin
 		vram_D			=> vram_D,		
 		color				=> spr_color);
 
-	process (x, y, mask_column0, bg_priority, spr_color, bg_color, overscan, display_on, gg)
+	process (x, y, mask_column0, bg_priority, spr_color, bg_color, overscan, display_on, gg, smode_M1, smode_M3)
 		variable spr_active	: boolean;
 		variable bg_active	: boolean;
 	begin

--- a/vdp_sprite_shifter.vhd
+++ b/vdp_sprite_shifter.vhd
@@ -9,7 +9,9 @@ Port(
 	ce_pix: in  STD_LOGIC;
 	x		: in  std_logic_vector (7 downto 0);
 	spr_x	: in  std_logic_vector (7 downto 0);
-	shift   : in std_logic;
+	shift : in  std_logic;
+	load  : in  boolean;
+	x248  : in  boolean; -- idem load but for shifted sprites
 	spr_d0: in  std_logic_vector (7 downto 0);
 	spr_d1: in  std_logic_vector (7 downto 0);
 	spr_d2: in  std_logic_vector (7 downto 0);
@@ -32,7 +34,7 @@ begin
 	process (clk_sys)	begin
 		if rising_edge(clk_sys) then
 			if ce_pix = '1' then
-				if (spr_x=x and shift='0') or (spr_x=x+8 and shift='1') then
+				if (spr_x=x and shift='0' and load) or (spr_x=x+8 and shift='1' and x248) then
 					shift0 <= spr_d0;
 					shift1 <= spr_d1;
 					shift2 <= spr_d2;

--- a/vdp_sprites.vhd
+++ b/vdp_sprites.vhd
@@ -122,7 +122,7 @@ begin
 							state <= WAITING; -- stop
 						elsif (delta(8 downto 3)="00000" and tall='0') or (delta(8 downto 4)="0000" and tall='1') then
 							data_address(5 downto 2) <= delta(3 downto 0);
-							if (count>=8 and y<192) then
+							if (count>=8 and ( y<192 or (y<224 and smode_M1='1') or (y<240 and smode_M3='1') ) ) then
 								overflow <= '1';
 							end if;
 							if ((count<MAX_SPPL+1) and (count<8 or sp64='1')) then

--- a/vdp_sprites.vhd
+++ b/vdp_sprites.vhd
@@ -70,6 +70,12 @@ begin
 			x		=> x(7 downto 0),
 			spr_x	=> spr_x(i),
 			shift	=> shift,
+			-- as we pass only 8 bits for the x address, we need to make the difference
+			-- between x=255 and x=511 in some way inside the shifters, or we'll have spurious
+			-- signals difficult to filter outside them. The compare operators are kept
+			-- outside the module to avoid to have them duplicated 64 times.
+			load  => x<256, --load range
+			x248  => x<248 or x>=504, --load range for shifted sprites
 			spr_d0=> spr_d0(i),
 			spr_d1=> spr_d1(i),
 			spr_d2=> spr_d2(i),
@@ -90,6 +96,7 @@ begin
 					(others=>'0') when others;
 
 	ce_spload <= ce_vdp when (MAX_SPPL<8 or sp64='0') else ce_sp;
+	
 	process (clk_sys)
 		variable y9 	: std_logic_vector(8 downto 0);
 		variable d9		: std_logic_vector(8 downto 0);
@@ -98,13 +105,14 @@ begin
 		if rising_edge(clk_sys) then
 			if ce_spload='1' then
 			
-				if x=255 then
+				if x=255 then  -- 
 					count <= 0;
 					enable <= (others=>false);
 					state <= COMPARE;
 					index <= (others=>'0');
+					overflow <= '0';
 				
-				elsif x>=496 then  --match vdp_main.vhd (384)
+				elsif x=496 then  --match vdp_main.vhd (384)
 					state <= WAITING;
 					
 				else
@@ -114,7 +122,7 @@ begin
 						d9 := d9-256;
 					end if;
 					delta := y9-d9;
-					overflow <= '0';
+					--overflow <= '0';
 					
 					case state is
 					when COMPARE =>
@@ -131,7 +139,7 @@ begin
 								state <= WAITING;
 							end if;
 						else
-							if index<63 then
+							if index<MAX_SPPL then
 								index <= index+1;
 							else
 								state <= WAITING;
@@ -180,7 +188,7 @@ begin
 		variable collision 	: std_logic_vector(7 downto 0);
 	begin
 		if rising_edge(clk_sys) then
-			if ce_vdp='1' then
+			if ce_vdp='1' then 
 				color <= (others=>'0');
 				collision := (others=>'0');
 				for i in MAX_SPPL downto 8 loop
@@ -196,7 +204,7 @@ begin
 				end loop;
 				case collision is
 				when x"00" | x"01" | x"02" | x"04" | x"08" | x"10" | x"20" | x"40" | x"80" =>
-					collide <= '0';
+					collide <= '0';	
 				when others =>
 					collide <= '1';
 				end case;

--- a/vdp_sprites.vhd
+++ b/vdp_sprites.vhd
@@ -17,6 +17,8 @@ port (
 	char_high_bit	: in  std_logic;
 	tall				: in  std_logic;
 	shift				: in  std_logic;
+	smode_M1			: in	std_logic ;
+	smode_M3			: in	std_logic ;
 	vram_A			: out STD_LOGIC_VECTOR (13 downto 0);
 	vram_D			: in  STD_LOGIC_VECTOR (7 downto 0);
 	x					: in  STD_LOGIC_VECTOR (8 downto 0);
@@ -116,7 +118,7 @@ begin
 					
 					case state is
 					when COMPARE =>
-						if d9=208 then
+						if d9=208 and smode_M1='0' and smode_M3='0' then  -- hD0 stops only in 192 mode
 							state <= WAITING; -- stop
 						elsif (delta(8 downto 3)="00000" and tall='0') or (delta(8 downto 4)="0000" and tall='1') then
 							data_address(5 downto 2) <= delta(3 downto 0);

--- a/video.vhd
+++ b/video.vhd
@@ -38,24 +38,27 @@ begin
 				if hcount=487 then
 					vcount <= vcount + 1;
 					if pal = '1' then
-						-- VCounter: 0-242, 442-511 = 313 steps
+						-- VCounter: 0-258, 458-511 = 313 steps
 						if smode_M1='1' then
 							if vcount = 258 then
 								vcount <= conv_std_logic_vector(458,9);
-							elsif vcount = 485 then
+						--		vsync <= '1';
+							elsif vcount = 254 then
 								vsync <= '1';
-							elsif vcount = 488 then
+							elsif vcount = 257 then
 								vsync <= '0';
 							end if;
 						elsif smode_M3='1' then
+						-- VCounter: 0-266, 466-511 = 313 steps
 							if vcount = 266 then
 								vcount <= conv_std_logic_vector(466,9);
-							elsif vcount = 489 then
+							elsif vcount = 468 then
 								vsync <= '1';
-							elsif vcount = 492 then
+							elsif vcount = 471 then
 								vsync <= '0';
 							end if;
 						else
+						-- VCounter: 0-242, 442-511 = 313 steps
 							if vcount = 242 then
 								vcount <= conv_std_logic_vector(442,9);
 							elsif vcount = 458 then
@@ -65,21 +68,22 @@ begin
 							end if;
 						end if;
 					else
-					-- mode 240 lines is said to not work on NTSC anyway, so ...
+					-- NTSC mode 224 lines ...
 						if smode_M1='1' then
-							if vcount = 234 then
+							if vcount = 234 then 
 								vcount <= conv_std_logic_vector(485,9);
-							elsif vcount = 488 then
+							elsif vcount = 487 then
 								vsync <= '1';
-							elsif vcount = 491 then
+							elsif vcount = 490 then
 								vsync <= '0';
 							end if;
-						elsif smode_M3='1' then -- this mode wont work anyway
-							if vcount = 242 then
+					-- NTSC mode 240 lines -- this mode is not suposed to work anyway
+						elsif smode_M3='1' then 
+							if vcount = 242 then -- needs to be > 240 to generate an IRQ
 								vcount <= conv_std_logic_vector(491,9);
-							elsif vcount = 493 then
+							elsif vcount = 494 then
 								vsync <= '1';
-							elsif vcount = 496 then
+							elsif vcount = 497 then
 								vsync <= '0';
 							end if;
 						else
@@ -112,14 +116,13 @@ begin
 	x	<= hcount;
 	y	<= vcount;
 
-	vbl_st  <= conv_std_logic_vector(224,9) when smode_M1='1'
-			else conv_std_logic_vector(240,9) when smode_M3='1'
+	vbl_st  <=  conv_std_logic_vector(224,9) when smode_M1 = '1'
+			else conv_std_logic_vector(240,9) when smode_M3 = '1'
 			else conv_std_logic_vector(215,9) when border = '1' and gg = '0'
 			else conv_std_logic_vector(192,9) when (border xor gg) = '0'
 			else conv_std_logic_vector(168,9);
 			
-	vbl_end <= conv_std_logic_vector(000,9) when smode_M1='1'
-			else conv_std_logic_vector(000,9) when smode_M3='1'
+	vbl_end <= conv_std_logic_vector(000,9) when smode_M1 = '1' or smode_M3 = '1' 
 			else conv_std_logic_vector(488,9) when border = '1' and gg = '0'
 			else conv_std_logic_vector(000,9) when (border xor gg) = '0'
 			else conv_std_logic_vector(024,9);
@@ -140,7 +143,7 @@ begin
 				if (hcount=hbl_end) then
 					hblank <= '0';
 				elsif (hcount=hbl_st) then
-					hblank<='1';
+					hblank <= '1';
 				end if;
 				
 				if (vcount=vbl_end) then

--- a/video.vhd
+++ b/video.vhd
@@ -24,6 +24,7 @@ end video;
 
 architecture Behavioral of video is
 
+	signal zcount:			std_logic_vector(8 downto 0) ;
 	signal hcount:			std_logic_vector(8 downto 0) := (others => '0');
 	signal vcount:			std_logic_vector(8 downto 0) := (others => '0');
 
@@ -35,26 +36,24 @@ begin
 	begin
 		if rising_edge(clk) then
 			if ce_pix = '1' then
-				if hcount=487 then
+				if hcount=487	then
 					vcount <= vcount + 1;
 					if pal = '1' then
 						-- VCounter: 0-258, 458-511 = 313 steps
 						if smode_M1='1' then
 							if vcount = 258 then
 								vcount <= conv_std_logic_vector(458,9);
-						--		vsync <= '1';
 							elsif vcount = 254 then
 								vsync <= '1';
 							elsif vcount = 257 then
 								vsync <= '0';
 							end if;
 						elsif smode_M3='1' then
-						-- VCounter: 0-266, 466-511 = 313 steps
 							if vcount = 266 then
-								vcount <= conv_std_logic_vector(466,9);
-							elsif vcount = 468 then
+								vcount <= conv_std_logic_vector(482,9);
+							elsif vcount = 478 then
 								vsync <= '1';
-							elsif vcount = 471 then
+							elsif vcount = 481 then
 								vsync <= '0';
 							end if;
 						else
@@ -79,11 +78,11 @@ begin
 							end if;
 					-- NTSC mode 240 lines -- this mode is not suposed to work anyway
 						elsif smode_M3='1' then 
-							if vcount = 242 then -- needs to be > 240 to generate an IRQ
-								vcount <= conv_std_logic_vector(491,9);
-							elsif vcount = 494 then
+							if vcount = 261 then -- needs to be > 240 to generate an IRQ
+								vcount <= conv_std_logic_vector(0,9);
+							elsif vcount = 257 then
 								vsync <= '1';
-							elsif vcount = 497 then
+							elsif vcount = 260 then
 								vsync <= '0';
 							end if;
 						else

--- a/video.vhd
+++ b/video.vhd
@@ -11,6 +11,9 @@ entity video is
 		gg:				in  std_logic;
 		border:        in  std_logic := '1';
 		mask_column:	in  std_logic := '0';
+		smode_M1:		in	 std_logic;
+		smode_M3:		in	 std_logic;
+		
 		x: 				out std_logic_vector(8 downto 0);
 		y:					out std_logic_vector(8 downto 0);
 		hsync:			out std_logic;
@@ -36,21 +39,58 @@ begin
 					vcount <= vcount + 1;
 					if pal = '1' then
 						-- VCounter: 0-242, 442-511 = 313 steps
-						if vcount = 242 then
-							vcount <= conv_std_logic_vector(442,9);
-						elsif vcount = 458 then
-							vsync <= '1';
-						elsif vcount = 461 then
-							vsync <= '0';
+						if smode_M1='1' then
+							if vcount = 258 then
+								vcount <= conv_std_logic_vector(458,9);
+							elsif vcount = 485 then
+								vsync <= '1';
+							elsif vcount = 488 then
+								vsync <= '0';
+							end if;
+						elsif smode_M3='1' then
+							if vcount = 266 then
+								vcount <= conv_std_logic_vector(466,9);
+							elsif vcount = 489 then
+								vsync <= '1';
+							elsif vcount = 492 then
+								vsync <= '0';
+							end if;
+						else
+							if vcount = 242 then
+								vcount <= conv_std_logic_vector(442,9);
+							elsif vcount = 458 then
+								vsync <= '1';
+							elsif vcount = 461 then
+								vsync <= '0';
+							end if;
 						end if;
 					else
+					-- mode 240 lines is said to not work on NTSC anyway, so ...
+						if smode_M1='1' then
+							if vcount = 234 then
+								vcount <= conv_std_logic_vector(485,9);
+							elsif vcount = 488 then
+								vsync <= '1';
+							elsif vcount = 491 then
+								vsync <= '0';
+							end if;
+						elsif smode_M3='1' then -- this mode wont work anyway
+							if vcount = 242 then
+								vcount <= conv_std_logic_vector(491,9);
+							elsif vcount = 493 then
+								vsync <= '1';
+							elsif vcount = 496 then
+								vsync <= '0';
+							end if;
+						else
 						-- VCounter: 0-218, 469-511 = 262 steps
-						if vcount = 218 then
-							vcount <= conv_std_logic_vector(469,9);
-						elsif vcount = 471 then
-							vsync <= '1';
-						elsif vcount = 474 then
-							vsync <= '0';
+							if vcount = 218 then
+								vcount <= conv_std_logic_vector(469,9);
+							elsif vcount = 471 then
+								vsync <= '1';
+							elsif vcount = 474 then
+								vsync <= '0';
+							end if;
 						end if;
 					end if;
 				end if;
@@ -72,11 +112,15 @@ begin
 	x	<= hcount;
 	y	<= vcount;
 
-	vbl_st  <= conv_std_logic_vector(215,9) when border = '1' and gg = '0'
+	vbl_st  <= conv_std_logic_vector(224,9) when smode_M1='1'
+			else conv_std_logic_vector(240,9) when smode_M3='1'
+			else conv_std_logic_vector(215,9) when border = '1' and gg = '0'
 			else conv_std_logic_vector(192,9) when (border xor gg) = '0'
 			else conv_std_logic_vector(168,9);
 			
-	vbl_end <= conv_std_logic_vector(488,9) when border = '1' and gg = '0'
+	vbl_end <= conv_std_logic_vector(000,9) when smode_M1='1'
+			else conv_std_logic_vector(000,9) when smode_M3='1'
+			else conv_std_logic_vector(488,9) when border = '1' and gg = '0'
 			else conv_std_logic_vector(000,9) when (border xor gg) = '0'
 			else conv_std_logic_vector(024,9);
 


### PR DESCRIPTION
- implements the 224/240 extended mode,
- straighten timing of video  and other signals
- insure most VDPTest compliance (one test is failing, by only half a clock)
- fixes a few secondary bugs
- Works with MIST and MISTer

it plays Fantastic Dizzy in NTSC mode.
Known issues : 
- Some timing problem with Dizzy in PAL mode.
- 240 mode not really tested