### PR TITLE
1-pixel desync between sprites and background

### DIFF
--- a/vdp.vhd
+++ b/vdp.vhd
@@ -381,8 +381,11 @@ begin
 			
 			if ce_vdp = '1' then
 				xspr_collide_shift(13 downto 1) <= xspr_collide_shift(12 downto 0) ;
-				xspr_collide_shift(0) <= spr_collide ;
-				
+				if (x<=256) then
+					xspr_collide_shift(0) <= spr_collide ;
+				else
+					xspr_collide_shift(0) <= '0' ;
+				end if;
 				if xspr_collide_shift(13)='1'  and 
 					display_on='1' and
 					(y<234 or (xmode_M1='0' and xmode_M3='0' and y>=496)) 

--- a/vdp_background.vhd
+++ b/vdp_background.vhd
@@ -55,9 +55,11 @@ begin
 		-- same change in vdp_main around line 79 (line_reset)
 		--
 					if disable_hscroll='0' or screen_y>=16 then
-						x <= 232-scroll_x+1; -- temporary workaround of 1pix roll - needs better fix!
+													-- if you mess with this check Sangokushi3 scroll during
+													-- the presentation + scroll of the top line during fight
+						x <= 232-scroll_x;   -- temporary workaround of 1pix roll - needs better fix!
 					else
-						x <= "11101001"; -- 233
+						x <= "11101000"; -- 256-24=232
 					end if;
 				else
 					x <= x + 1;
@@ -141,10 +143,10 @@ begin
 					color(4)	<= palette;
 					priority	<= priority_latch;
 				when others =>
-					shift0(7 downto 1) <= shift0(6 downto 0);
-					shift1(7 downto 1) <= shift1(6 downto 0);
-					shift2(7 downto 1) <= shift2(6 downto 0);
-					shift3(7 downto 1) <= shift3(6 downto 0);
+					shift0(7 downto 1) <= shift0(6 downto 0) ;
+					shift1(7 downto 1) <= shift1(6 downto 0) ;
+					shift2(7 downto 1) <= shift2(6 downto 0) ;
+					shift3(7 downto 1) <= shift3(6 downto 0) ;
 				end case;
 			end if;
 		end if;

--- a/vdp_main.vhd
+++ b/vdp_main.vhd
@@ -127,7 +127,7 @@ begin
 		variable spr_active	: boolean;
 		variable bg_active	: boolean;
 	begin
-		if ((x>=48 and x<208) or (gg='0' and x<256)) and
+		if ((x>48 and x<=208) or (gg='0' and x<=256)) and
 			(mask_column0='0' or x>=8) and display_on='1' then
 			if (((y>=24 and y<168) and smode_M1='0')
 				or ((y>=40 and y<184) and smode_M1='1')

--- a/vdp_sprite_shifter.vhd
+++ b/vdp_sprite_shifter.vhd
@@ -9,7 +9,6 @@ Port(
 	ce_pix: in  STD_LOGIC;
 	x		: in  std_logic_vector (7 downto 0);
 	spr_x	: in  std_logic_vector (7 downto 0);
-	shift : in  std_logic;
 	load  : in  boolean;
 	x248  : in  boolean; -- idem load but for shifted sprites
 	wide_n: in  boolean; -- if sprites are wide reg1 bit 0
@@ -34,7 +33,7 @@ begin
 	process (clk_sys)	begin
 		if rising_edge(clk_sys) then
 			if ce_pix = '1' then
-				if (spr_x=x and shift='0' and load) or (spr_x=x+8 and shift='1' and x248) then
+				if (spr_x=x and load) or (spr_x=x+8 and x248) then
 					shift0 <= spr_d0;
 					shift1 <= spr_d1;
 					shift2 <= spr_d2;

--- a/vdp_sprites.vhd
+++ b/vdp_sprites.vhd
@@ -70,13 +70,12 @@ begin
 			ce_pix=> ce_pix,
 			x		=> x(7 downto 0),
 			spr_x	=> spr_x(i),
-			shift	=> shift,
 			-- as we pass only 8 bits for the x address, we need to make the difference
 			-- between x=255 and x=511 in some way inside the shifters, or we'll have spurious
 			-- signals difficult to filter outside them. The compare operators are kept
 			-- outside the module to avoid to have them duplicated 64 times.
-			load  => x<256, --load range
-			x248  => x<248 or x>=504, --load range for shifted sprites
+			load  => shift='0' and x<256, --load range
+			x248  => shift='1' and (x<248 or x>=504), --load range for shifted sprites
 			wide_n	=> wide='0',
 			spr_d0=> spr_d0(i),
 			spr_d1=> spr_d1(i),
@@ -107,7 +106,9 @@ begin
 		if rising_edge(clk_sys) then
 			if ce_spload='1' then
 			
-				if x=255 then  -- 
+				if x=257 then  -- we need step 256 to display the very last sprite pixel
+									-- and one more pixel because the test here is made sync'ed
+									-- by ce_spload which could be very early regarding ce_vdp
 					count <= 0;
 					enable <= (others=>false);
 					state <= COMPARE;

--- a/video.vhd
+++ b/video.vhd
@@ -127,14 +127,14 @@ begin
 			else conv_std_logic_vector(000,9) when (border xor gg) = '0'
 			else conv_std_logic_vector(024,9);
 
-	hbl_st  <= conv_std_logic_vector(269,9) when border = '1' and gg = '0'
-			else conv_std_logic_vector(255,9) when (border xor gg) = '0'
-			else conv_std_logic_vector(207,9);
+	hbl_st  <= conv_std_logic_vector(270,9) when border = '1' and gg = '0'
+			else conv_std_logic_vector(256,9) when (border xor gg) = '0'
+			else conv_std_logic_vector(208,9);
 
-	hbl_end <= conv_std_logic_vector(499,9) when border = '1' and gg = '0'
-			else conv_std_logic_vector(007,9) when (border xor gg) = '0' and mask_column = '1'
-			else conv_std_logic_vector(511,9) when (border xor gg) = '0'
-			else conv_std_logic_vector(047,9);
+	hbl_end <= conv_std_logic_vector(500,9) when border = '1' and gg = '0'
+			else conv_std_logic_vector(008,9) when (border xor gg) = '0' and mask_column = '1'
+			else conv_std_logic_vector(000,9) when (border xor gg) = '0'
+			else conv_std_logic_vector(048,9);
 
 	process (clk)
 	begin


### PR DESCRIPTION
- resync sprites and background, fix timings
- fix clock domain mixup making wrong sprite stop at x=256
- add collision test for x>256 because previous fix
- simplify sprites shifters (a little)