### PR TITLE
add cheat codes and autosave

### DIFF
--- a/SMS.qsf
+++ b/SMS.qsf
@@ -364,6 +364,7 @@ set_global_assignment -name QIP_FILE VM2413/OPLL.qip
 set_global_assignment -name QIP_FILE jt89/jt89.qip
 set_global_assignment -name SYSTEMVERILOG_FILE compressor.sv
 set_global_assignment -name SYSTEMVERILOG_FILE sdram.sv
+set_global_assignment -name SYSTEMVERILOG_FILE cheatcodes.sv
 set_global_assignment -name VHDL_FILE video.vhd
 set_global_assignment -name VHDL_FILE sprom.vhd
 set_global_assignment -name VHDL_FILE spram.vhd

--- a/SMS.sv
+++ b/SMS.sv
@@ -134,7 +134,7 @@ assign {UART_RTS, UART_TXD, UART_DTR} = 0;
 assign {SD_SCK, SD_MOSI, SD_CS} = '1;
 assign {DDRAM_CLK, DDRAM_BURSTCNT, DDRAM_ADDR, DDRAM_DIN, DDRAM_BE, DDRAM_RD, DDRAM_WE} = '0;
 
-assign LED_USER  = ioctl_download | bk_state ;
+assign LED_USER  = cart_download | bk_state | (status[23] & bk_pending);
 assign LED_DISK  = 0; // smode_M1 ? 2'b11 : 2'b10 ;
 assign LED_POWER = 0; // smode_M3 ? 2'b11 : 2'b10 ;
 
@@ -148,12 +148,16 @@ parameter CONF_STR1 = {
 	"FS,SMS;",
 	"FS,GG;",
 	"-;",
+	"FC,GG,Game Genie Code;",
+	"OO,Game Genie,ON,OFF;",
+	"-;",
 };
 parameter CONF_STR2 = {
 	"6,Load Backup RAM;"
 };
 parameter CONF_STR3 = {
 	"7,Save Backup RAM;",
+	"ON,Autosave,OFF,ON;",
 	"-;",
 	"O9,Aspect ratio,4:3,16:9;",
 	"O35,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
@@ -190,7 +194,7 @@ pll pll
 	.locked(locked)
 );
 
-wire reset = RESET | status[0] | buttons[1] | ioctl_download | bk_loading;
+wire reset = RESET | status[0] | buttons[1] | cart_download | bk_loading;
 
 //////////////////   HPS I/O   ///////////////////
 wire  [6:0] joy[4], joy_0, joy_1;
@@ -264,6 +268,10 @@ wire [21:0] ram_addr;
 wire  [7:0] ram_dout;
 wire        ram_rd;
 
+wire code_index = ioctl_index == 3;
+wire code_download = ioctl_download & code_index;
+wire cart_download = ioctl_download & ~code_index;
+
 sdram ram
 (
 	.*,
@@ -277,7 +285,7 @@ sdram ram
 	.we(rom_wr),
 	.we_ack(sd_wrack),
 
-	.raddr(ioctl_addr[9] ? (ram_addr - 10'd512) & cart_mask512 : ram_addr & cart_mask),
+	.raddr(cart_sz[9] ? (ram_addr - 10'd512) & cart_mask512 : ram_addr & cart_mask),
 	.dout(ram_dout),
 	.rd(ram_rd),
 	.rd_rdy()
@@ -290,13 +298,13 @@ reg  [23:0] romwr_a;
 always @(posedge clk_sys) begin
 	reg old_download, old_reset;
 
-	old_download <= ioctl_download;
+	old_download <= cart_download;
 	old_reset <= reset;
 
 	if(~old_reset && reset) ioctl_wait <= 0;
-	if(~old_download && ioctl_download) romwr_a <= 0;
+	if(~old_download && cart_download) romwr_a <= 0;
 	else begin
-		if(ioctl_wr) begin
+		if(ioctl_wr & cart_download) begin
 			ioctl_wait <= 1;
 			rom_wr <= ~rom_wr;
 		end else if(ioctl_wait && (rom_wr == sd_wrack)) begin
@@ -309,19 +317,63 @@ end
 assign AUDIO_S = 1;
 assign AUDIO_MIX = 1;
 
+reg [128:0] gg_code;
+
+// Code layout:
+// {clock bit, code flags,     32'b address, 32'b compare, 32'b replace}
+//  128        127:96          95:64         63:32         31:0
+// Integer values are in BIG endian byte order, so it up to the loader
+// or generator of the code to re-arrange them correctly.
+
+always_ff @(posedge clk_sys) begin
+	gg_code[128] <= 1'b0;
+
+	if (code_download & ioctl_wr) begin
+		case (ioctl_addr[3:0])
+			0:  gg_code[111:96]  <= ioctl_dout; // Flags Bottom Word
+			1:  gg_code[119:112]  <= ioctl_dout; // Flags Bottom Word
+			2:  gg_code[127:120] <= ioctl_dout; // Flags Top Word
+			3:  gg_code[127:112] <= ioctl_dout; // Flags Top Word
+			4:  gg_code[71:64]   <= ioctl_dout; // Address Bottom Word
+			5:  gg_code[79:72]   <= ioctl_dout; // Address Bottom Word
+			6:  gg_code[87:80]   <= ioctl_dout; // Address Top Word
+			7:  gg_code[95:88]   <= ioctl_dout; // Address Top Word
+			8:  gg_code[39:32]   <= ioctl_dout; // Compare Bottom Word
+			9:  gg_code[47:40]   <= ioctl_dout; // Compare Bottom Word
+			10: gg_code[55:48]   <= ioctl_dout; // Compare top Word
+			11: gg_code[63:56]   <= ioctl_dout; // Compare top Word
+			12: gg_code[7:0]    <= ioctl_dout; // Replace Bottom Word
+			13: gg_code[15:8]    <= ioctl_dout; // Replace Bottom Word
+			14: gg_code[23:16]   <= ioctl_dout; // Replace Top Word
+			15: begin
+				gg_code[31:24]   <= ioctl_dout; // Replace Top Word
+				gg_code[128]     <=  1'b1;      // Clock it in
+			end
+		endcase
+	end
+end
+
+
 reg  dbr = 0;
 always @(posedge clk_sys) begin
-	if(ioctl_download || bk_loading) dbr <= 1;
+	if(cart_download || bk_loading) dbr <= 1;
 end
 
 reg gg = 0;
 reg [21:0] cart_mask, cart_mask512;
+reg [24:0] cart_sz;
+
 always @(posedge clk_sys) begin
-	if(ioctl_wr) begin
+	reg old_download;
+	old_download <= cart_download;
+
+	if(ioctl_wr & cart_download) begin
 		cart_mask <= cart_mask | ioctl_addr[21:0];
 		cart_mask512 <= cart_mask512 | (ioctl_addr[21:0] - 10'd512);
 		if(!ioctl_addr) cart_mask <= 0;
 		if(ioctl_addr == 512) cart_mask512 <= 0;
+		if (old_download & ~cart_download)
+			cart_sz <= ioctl_index;
 		gg <= ioctl_index[4:0] == 2;
 	end;
 end
@@ -347,6 +399,10 @@ system #(MAX_SPPL) system
 	.bios_en(~status[11]),
 
 	.RESET_n(~reset),
+	.RST_COLD(cart_download),
+
+	.GG_EN(status[24]),
+	.GG_CODE(gg_code),
 
 	.rom_rd(ram_rd),
 	.rom_a(ram_addr),
@@ -526,6 +582,16 @@ video_mixer #(.HALF_DEPTH(1), .LINE_LENGTH(300)) video_mixer
 
 
 /////////////////////////  STATE SAVE/LOAD  /////////////////////////////
+wire bk_save_write = nvram_we;
+reg bk_pending;
+
+always @(posedge clk_sys) begin
+	if (bk_ena && ~OSD_STATUS && bk_save_write)
+		bk_pending <= 1'b1;
+	else if (bk_state)
+		bk_pending <= 1'b0;
+end
+
 dpram #(.widthad_a(15)) nvram_inst
 (
 	.clock_a     (clk_sys),
@@ -540,7 +606,7 @@ dpram #(.widthad_a(15)) nvram_inst
 	.q_b         (sd_buff_din)
 );
 
-wire downloading = ioctl_download;
+wire downloading = cart_download;
 reg old_downloading = 0;
 reg bk_ena = 0;
 always @(posedge clk_sys) begin
@@ -553,7 +619,7 @@ always @(posedge clk_sys) begin
 end
 
 wire bk_load    = status[6];
-wire bk_save    = status[7];
+wire bk_save    = status[7] | (bk_pending & OSD_STATUS && status[23]);
 reg  bk_loading = 0;
 reg  bk_state   = 0;
 

--- a/cheatcodes.sv
+++ b/cheatcodes.sv
@@ -1,0 +1,107 @@
+// Cheat Code handling by Kitrinx
+// Apr 21, 2019
+
+// Code layout:
+// {clock bit, code flags,     32'b address, 32'b compare, 32'b replace}
+//  128        127:96          95:64         63:32         31:0
+// Integer values are in BIG endian byte order, so it up to the loader
+// or generator of the code to re-arrange them correctly.
+
+module CODES(
+	input  clk,        // Best to not make it too high speed for timing reasons
+	input  cold_reset, // This should only be triggered when a new rom is loaded, not warm reset
+	input  enable,
+	input  [ADDR_WIDTH - 1:0] addr_in,
+	input  [DATA_WIDTH - 1:0] data_in,
+	input  [128:0] code,
+	output genie_ovr,
+	output [DATA_WIDTH - 1:0] genie_data
+);
+
+parameter ADDR_WIDTH   = 16; // Not more than 32
+parameter DATA_WIDTH   = 8;  // Not more than 32
+
+localparam MAX_CODES   = 32;
+localparam INDEX_SIZE  = 5; // Number of bits for index, must accomodate MAX_CODES
+
+localparam DATA_S      = DATA_WIDTH - 1;
+localparam COMP_S      = DATA_S + DATA_WIDTH;
+localparam ADDR_S      = COMP_S + ADDR_WIDTH;
+localparam COMP_F_S    = ADDR_S + 1;
+localparam ENA_F_S     = COMP_F_S + 1;
+localparam CODE_WIDTH  = ENA_F_S + 1;
+
+reg [ENA_F_S:0] codes[MAX_CODES];
+
+wire [ADDR_WIDTH-1: 0] code_addr    = code[64+:ADDR_WIDTH];
+wire [DATA_WIDTH-1: 0] code_compare = code[32+:DATA_WIDTH];
+wire [DATA_WIDTH-1: 0] code_data    = code[0+:DATA_WIDTH];
+wire code_comp_f = code[96];
+
+wire [COMP_F_S:0] code_trimmed = {code_comp_f, code_addr, code_compare, code_data};
+
+// If MAX_INDEX is changes, these need to be made larger
+wire [INDEX_SIZE-1:0] index, dup_index;
+reg [INDEX_SIZE-1:0] next_index;
+wire found_dup;
+
+assign index = found_dup ? dup_index : next_index;
+
+// See if the code exists already, so it can be disabled if loaded again
+always_comb begin
+	int x;
+	dup_index = 0;
+	found_dup = 0;
+
+	for (x = 0; x < MAX_CODES; x = x + 1'b1) begin
+		if (codes[x][ADDR_S-:ADDR_WIDTH] == code_addr) begin
+			dup_index = x[INDEX_SIZE-1:0];
+			found_dup = 1'b1;
+		end
+	end
+end
+
+reg code_change;
+always_ff @(posedge clk) begin
+	int x;
+	if (cold_reset) begin
+		next_index <= 0;
+		code_change <= 0;
+		for (x = 0; x < MAX_CODES; x = x + 1) codes[x] <= {CODE_WIDTH{1'd0}};
+	end else begin
+		code_change <= code[128];
+		if (code[128] & ~code_change) begin // detect posedge
+			// Disable the code if it's the exact same code loaded again, otherwise,
+			// replace it enabled if it has the same address, otherwise, add a new code
+			codes[index] <= found_dup ? ((codes[index][COMP_S:0] == {code_compare, code_data}) ?
+				{codes[index][ENA_F_S] ? 1'b0 : 1'b1, code_trimmed} : {1'b1, code_trimmed}) : {1'b1, code_trimmed};
+			if (~found_dup) next_index <= next_index + 1'b1;
+		end
+	end
+end
+
+always_comb begin
+	int x;
+	genie_ovr = 1'b0;
+	genie_data = 8'd0;
+	x = 0;
+
+	if (enable) begin
+		for (x = 0; x < MAX_CODES; x = x + 1'b1) begin
+			if (codes[x][ENA_F_S] && codes[x][ADDR_S-:ADDR_WIDTH] == addr_in) begin
+				if (codes[x][COMP_F_S]) begin        // Check for compare bit if needed
+					if (codes[x][COMP_S-:DATA_WIDTH] == data_in) begin
+						genie_ovr = 1'b1;
+						genie_data = codes[x][DATA_S-:DATA_WIDTH];
+					end
+				end else begin                 // Otherwise just match
+					genie_ovr = 1'b1;
+					genie_data = codes[x][DATA_S-:DATA_WIDTH];
+				end
+			end
+		end
+	end
+end
+
+
+endmodule


### PR DESCRIPTION
Codes/autosave work for both GG and SMS.

The extension .gg is the same as game gear, but it sounds like that might get resolved anyway.

SMS autosaving has no check to see if games support saves or not, because there is no header or other info, but in my limited testing it did not seem to cause problems. Users can keep it off if they want.