### PR TITLE
Limiting FM disable option to only SMS. Game Gear has FM built in.

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -171,7 +171,7 @@ parameter CONF_STR = {
 `ifdef USE_SP64
 	"O8,Sprites per line,Std(8),All(64);",
 `endif
-	"OC,FM sound,Enable,Disable;",
+	"H2OC,SMS FM sound,Enable,Disable;",
 	"OA,Region,US/UE,Japan;",
 	"-;",
 	"O1,Swap joysticks,No,Yes;",
@@ -241,7 +241,7 @@ hps_io #(.STRLEN($size(CONF_STR)>>3), .WIDE(0)) hps_io
 
 	.buttons(buttons),
 	.status(status),
-	.status_menumask({~gg_avail,~bk_ena}),
+	.status_menumask({gg,~gg_avail,~bk_ena}),
 	.forced_scandoubler(forced_scandoubler),
 	.new_vmode(pal),
 
@@ -443,7 +443,7 @@ system #(MAX_SPPL) system
 	.region(status[10]),
 	.mapper_lock(status[15]),
 
-	.fm_ena(~status[12]),
+	.fm_ena(~status[12] | gg),
 	.audioL(audio_l),
 	.audioR(audio_r),
 


### PR DESCRIPTION
FM audio was optional on SMS, and games were coded to handle this, but it was built into Game Gear, and games handle the lack of FM audio poorly (Sonic 2 loud audio screeching). This lets you disable FM for SMS without fear of losing your hearing next time you launch a Game Gear game.