### PR TITLE
Fixing Game Gear IO behavior.

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -178,7 +178,7 @@ parameter CONF_STR = {
 	"OB,BIOS,Enable,Disable;",
 	"OF,Disable mapper,No,Yes;",
 	"OG,Serial,OFF,SNAC;",
-	"H2OH,Pause Btn Combo,No,Yes;",
+	"H3OH,Pause Btn Combo,No,Yes;",
 	"-;",
 	"R0,Reset;",
 	"J1,Fire 1,Fire 2,Pause;",
@@ -244,7 +244,7 @@ hps_io #(.STRLEN($size(CONF_STR)>>3), .WIDE(0)) hps_io
 
 	.buttons(buttons),
 	.status(status),
-	.status_menumask({~raw_serial,~gg_avail,~bk_ena}),
+	.status_menumask({~raw_serial,gg,~gg_avail,~bk_ena}),
 	.forced_scandoubler(forced_scandoubler),
 	.new_vmode(pal),
 	.gamma_bus(gamma_bus),

--- a/rtl/io.vhd
+++ b/rtl/io.vhd
@@ -110,7 +110,7 @@ begin
 					D_out(7) <= J2_down;
 					D_out(6) <= J2_up;
 					-- 5=j1_tr
-					if ctrl(0)='0' and region='0' then
+					if ctrl(0)='0' and region='0' and gg='0' then
 						D_out(5) <= ctrl(4);
 					else
 						D_out(5) <= J1_tr;
@@ -122,13 +122,13 @@ begin
 					D_out(0) <= J1_up;
 				else
 					-- 7=j2_th
-					if ctrl(3)='0' and region='0' then
+					if ctrl(3)='0' and region='0' and gg='0' then
 						D_out(7) <= ctrl(7);
 					else
 						D_out(7) <= J2_th;
 					end if;
 					-- 6=j1_th
-					if ctrl(1)='0' and region='0' then
+					if ctrl(1)='0' and region='0' and gg='0' then
 						D_out(6) <= ctrl(5);
 					else
 						D_out(6) <= J1_th;
@@ -136,7 +136,7 @@ begin
 					D_out(5) <= '1';
 					D_out(4) <= '1';
 					-- 4=j2_tr
-					if ctrl(2)='0' then
+					if ctrl(2)='0' and gg='0' then
 						D_out(3) <= ctrl(6);
 					else
 						D_out(3) <= J2_tr;


### PR DESCRIPTION
Game Gear doesn't do SMS-only region behavior. Doing so may cause some games to have their button 2 to become unresponsive. This fixes Aladdin and probably other games.

Also, fixing an OSD options mask that was lost when I squashed before the last PR.