### PR TITLE
Audio volume boost, better DAC for MiST.

### DIFF
--- a/mist/SMS.sv
+++ b/mist/SMS.sv
@@ -411,23 +411,19 @@ mist_video #(.SD_HCNT_WIDTH(10), .COLOR_DEPTH(4)) mist_video
 	.VGA_B(VGA_B)
 );
 
+
 //////////////////   AUDIO   //////////////////
 
-dac #(16) dacl
+hybrid_pwm_sd dac
 (
-	.clk_i(clk_sys),
-	.res_n_i(~reset),
-	.dac_i({~audioL[15], audioL[14:0]}),
-	.dac_o(AUDIO_L)
+	.clk(clk_sys),
+	.terminate(1'b0),
+	.d_l({~audioL[15], audioL[14:0]}),
+	.q_l(AUDIO_L),
+	.d_r({~audioR[15], audioR[14:0]}),
+	.q_r(AUDIO_R)
 );
 
-dac #(16) dacr
-(
-	.clk_i(clk_sys),
-	.res_n_i(~reset),
-	.dac_i({~audioR[15], audioR[14:0]}),
-	.dac_o(AUDIO_R)
-);
 
 /////////////////////////  STATE SAVE/LOAD  /////////////////////////////
 // 8k auxilary RAM - 32k doesn't fit

--- a/mist/sms_mist.qsf
+++ b/mist/sms_mist.qsf
@@ -316,4 +316,6 @@ set_global_assignment -name QIP_FILE ../rtl/T80/T80.qip
 set_global_assignment -name QIP_FILE pll.qip
 set_global_assignment -name SIGNALTAP_FILE output_files/vdp.stp
 set_global_assignment -name SIGNALTAP_FILE output_files/stp1.stp
+set_global_assignment -name VERILOG_FILE ../rtl/hybrid_pwm_sd.v
+set_global_assignment -name VHDL_FILE ../../../SMS_MiSTer/rtl/AudioMix.vhd
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/mist/sms_mist.qsf
+++ b/mist/sms_mist.qsf
@@ -317,5 +317,5 @@ set_global_assignment -name QIP_FILE pll.qip
 set_global_assignment -name SIGNALTAP_FILE output_files/vdp.stp
 set_global_assignment -name SIGNALTAP_FILE output_files/stp1.stp
 set_global_assignment -name VERILOG_FILE ../rtl/hybrid_pwm_sd.v
-set_global_assignment -name VHDL_FILE ../../../SMS_MiSTer/rtl/AudioMix.vhd
+set_global_assignment -name VHDL_FILE ../rtl/AudioMix.vhd
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/rtl/AudioMix.vhd
+++ b/rtl/AudioMix.vhd
@@ -1,0 +1,58 @@
+-- A simple audio mixer which avoids attenuation by clipping extremities
+--
+-- Copyright 2020 by Alastair M. Robinson
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.numeric_std.ALL;
+
+entity AudioMix is
+port
+(
+	clk : in std_logic;
+	reset_n : in std_logic;
+	audio_in_l1 : in signed(15 downto 0);
+	audio_in_l2 : in signed(15 downto 0);
+	audio_in_r1 : in signed(15 downto 0);
+	audio_in_r2 : in signed(15 downto 0);
+	audio_l : out signed(15 downto 0);
+	audio_r : out signed(15 downto 0)
+);
+end entity;
+
+architecture rtl of AudioMix is
+
+signal in1 : signed(16 downto 0);
+signal in2 : signed(16 downto 0);
+signal sum : signed(16 downto 0);
+signal overflow : std_logic;
+signal clipped : signed(16 downto 0);
+signal toggle : std_logic;
+
+begin
+
+in1(16)<=in1(15);
+in2(16)<=in2(15);
+
+in1(15 downto 0)<=audio_in_l1 when toggle='0' else audio_in_r1;
+in2(15 downto 0)<=audio_in_l2 when toggle='0' else audio_in_r2;
+
+sum<=in1+in2;
+overflow<=sum(15) xor sum(16);
+
+clipped<=sum when overflow='0' else (others=>sum(16));
+
+process(clk)
+begin
+	if rising_edge(clk) then
+		if toggle='0' then
+			audio_l<=clipped(15 downto 0);
+		else
+			audio_r<=clipped(15 downto 0);
+		end if;
+		toggle<=not toggle;
+	end if;
+end process;
+
+
+end architecture;

--- a/rtl/hybrid_pwm_sd.v
+++ b/rtl/hybrid_pwm_sd.v
@@ -1,0 +1,142 @@
+// Stereo Hybrid PWM / Sigma Delta converter
+//
+// Uses 5-bit PWM, wrapped within a 10-bit Sigma Delta, with the intention of
+// increasing the pulse width, since narrower pulses seem to equate to more noise
+//
+// Copyright 2012,2020,2021 by Alastair M. Robinson
+//
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that they will
+// be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>
+//
+
+module hybrid_pwm_sd
+(
+	input clk,
+	input terminate,
+	input [15:0] d_l,
+	input [15:0] d_r,
+	output reg q_l,
+	output reg q_r
+);
+
+
+// PWM portion of the DAC - a free-running 5-bit counter.
+// Output goes high when counter is 0
+// and goes low again when the threshold value is reached.
+
+reg [4:0] pwmcounter=5'b11111;
+reg [4:0] pwmthreshold_l = 5'd30;
+reg [4:0] pwmthreshold_r = 5'd30;
+
+always @(posedge clk) begin
+	pwmcounter<=pwmcounter+5'b1;
+	
+	if(pwmcounter==pwmthreshold_l)
+		q_l<=1'b0;
+
+	if(pwmcounter==pwmthreshold_r)
+		q_r<=1'b0;
+
+	if(pwmcounter==5'b11111)
+	begin
+		q_l<=1'b1;
+		q_r<=1'b1;
+	end
+
+end
+
+
+// Anti-pop - at power-on ramp smoothly from near-maximum to midpoint,
+// then cut over to the core's audio output.
+
+// After initialisation, the terminate input going high
+// will prompt a ramp back up to maximum to avoid a pop
+// on core-change.
+
+reg term_ena=1'b0;
+wire terminated = terminate & term_ena;
+
+reg [13:0] initctr = 14'h3e00;
+wire init = initctr[13];
+reg [13:0] initctr_l = 14'h3e00;
+
+always @(posedge clk) begin
+	if(init && dump) begin
+		initctr_l<=initctr; // Lags one step behind to avoid wrapping from max -> 0 on terminate
+		if(terminate && term_ena)
+			initctr <= initctr+1;	// Increase the counter on termination	
+		else
+			initctr <= initctr-1;	// Decresae the counter on power-on
+	end
+	if(!init && terminate)
+		term_ena<=1'b1;	// Termination can't start until init is complete.
+	if(!init && terminate && !term_ena)
+		initctr <= initctr+1;	// Kick-start the termination, setting initctr[13]
+end
+
+// Periodic dumping of the accumulator to kill standing tones.
+// Yes, I know, yuck.  In practice it works better than would be expected.
+reg [7:0] dumpcounter;
+reg dump;
+
+always @(posedge clk) begin
+	dump <=1'b0;
+	if(pwmcounter==5'b11111)
+	begin
+		dumpcounter<=dumpcounter+1;
+		dump<=dumpcounter==0 ? 1'b1 : 1'b0;
+	end
+end
+
+
+// The Sigma Delta portion of the DAC
+
+// The most expensive part, the multiply-and-add (which Quartus implements
+// as shift-and-add due to the fixed factor) is multiplexed between the left
+// and right channels, switching between the two every time the counters are reloaded.
+
+reg [33:0] scaledin = 33'hF0000000;
+reg [15:0] sigma_l = 16'hf000;
+reg [15:0] sigma_r = 16'hf000;
+
+reg muxtoggle;
+wire [15:0] mux_in;
+assign mux_in = (init | terminated) ? {initctr_l[13:0],2'b00} : ( muxtoggle ? d_r : d_l );
+
+always @(posedge clk) begin
+	if(pwmcounter==5'b11111) // Update thresholds as PWM cycle ends
+	begin	
+		scaledin<=33'h8000000 // (1<<(16-5))<<16     offset to keep centre aligned.
+			+({1'b0,mux_in}*16'hf000); // + d_l * 30<<(16-5);
+
+		// Pick a new PWM threshold using a Sigma Delta
+		if(muxtoggle) begin
+			sigma_l<=scaledin[31:16]+{5'b00000,sigma_l[10:0]};	// Will use previous iteration's scaledin value
+			pwmthreshold_l<=sigma_l[15:11]; // Will lag 2 cycles behind, but shouldn't matter.
+		end else begin
+			sigma_r<=scaledin[31:16]+{5'b00000,sigma_r[10:0]};	// Will use previous iteration's scaledin value
+			pwmthreshold_r<=sigma_r[15:11]; // Will lag 2 cycles behind, but shouldn't matter.
+		end
+
+		muxtoggle<=!muxtoggle;
+	end
+
+	if(dump)	// dump the accumulator
+	begin
+		sigma_l[10:0]<=11'h100_00000000;
+		sigma_r[10:0]<=11'b100_00000000;
+	end
+end
+
+endmodule


### PR DESCRIPTION
The audio volume of the SMS core is rather low, and coupled with the simple 1-bit DAC this was causing poor audio quality on MiST ( see this issue:  https://github.com/mist-devel/mist-binaries/issues/105 )

This pull request uses a better DAC, and also gives the audio volume a significant boost, bringing it more inline with other cores.  These fixes (but especially the better DAC) fix the sound quality issues on MiST.