### PR TITLE
VDP: adjust collision flag outside of active area

### DIFF
--- a/rtl/vdp_sprites.vhd
+++ b/rtl/vdp_sprites.vhd
@@ -88,6 +88,7 @@ begin
 			color => spr_color(i),
 			active=> spr_active(i)
 		);
+
 	end generate;
 
 	with smode_M4 & state select
@@ -298,7 +299,11 @@ begin
 				when x"00" | x"01" | x"02" | x"04" | x"08" | x"10" | x"20" | x"40" | x"80" =>
 					collide <= '0';	
 				when others =>
-					collide <= '1';
+					if ( y<192 or (y<224 and smode_M1='1') or (y<240 and smode_M3='1') or y(8) = '1' ) then
+						collide <= '1';
+					else
+						collide <= '0';
+					end if;
 				end case;
 			end if;
 		end if;


### PR DESCRIPTION
Don't set the collision between the last line and y=256
Fixes Donkey, VDP test still pass
Bug: #84