### PR TITLE
Remove compressor from MiSTer - no longer needed due to volume boost.

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -688,12 +688,15 @@ spram #(.widthad_a(13)) ram_inst
 
 wire [15:0] audio_l, audio_r; 
 
-compressor compressor
-(
-	clk_sys,
-	audio_l[15:4], audio_r[15:4],
-	AUDIO_L,       AUDIO_R
-); 
+assign AUDIO_L=audio_l;
+assign AUDIO_R=audio_r;
+
+//compressor compressor
+//(
+//	clk_sys,
+//	audio_l[15:4], audio_r[15:4],
+//	AUDIO_L,       AUDIO_R
+//); 
 
 wire [8:0] x;
 wire [8:0] y;


### PR DESCRIPTION
The compressor was presumably added in the past to boost the core's volume, but has the side-effect of truncating low bits from the audio (and then amplifying the newly-introduced intervals). Since the core's volume is now significantly higher this shouldn't be needed any more.