### PR TITLE
Add support for Sega System E arcade games

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Sega Master System and Game Gear for the [MiSTer](https://github.com/MiSTer-devel/Main_MiSTer/wiki) and [MiST](https://github.com/mist-devel/mist-board/wiki) boards
- 
+
 ### Installation:
 * Copy the *.rbf file at the root of the SD card.
 * Copy *.SMS ROMs into SMS folder.
 
 ### Features: 
 * Master System, Game Gear and SG-1000 Support
+* Sega System E arcade hardware support
 * NTSC & PAL Support
 * Hide Borders Option - Allows you to fill the screen vertically without black borders.
 * FM Audio Support

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sega Master System and Game Gear for the [MiSTer](https://github.com/MiSTer-devel/Main_MiSTer/wiki) and [MiST](https://github.com/mist-devel/mist-board/wiki) boards
-
+ 
 ### Installation:
 * Copy the *.rbf file at the root of the SD card.
 * Copy *.SMS ROMs into SMS folder.

--- a/SMS.sv
+++ b/SMS.sv
@@ -209,26 +209,30 @@ video_freak video_freak
 // 0         1         2         3          4         5         6   
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXX
 
 `include "build_id.v"
 parameter CONF_STR = {
 	"SMS;;",
 	"-;",
-	"FS1,SMSSG;",
-	"FS2,GG;",
+	"H8FS1,SMSSG;",
+	"H8FS2,GG;",
+	"H8-;",
+	"DIP;",
 	"-;",
 	"C,Cheats;",
 	"H1OO,Cheats enabled,ON,OFF;",
 	"-;",
-	"D0R6,Load Backup RAM;",
-	"D0R7,Save Backup RAM;",
-	"D0OP,Autosave,OFF,ON;",
+	"H8D0R6,Load Backup RAM;",
+	"H8D0R7,Save Backup RAM;",
+	"H8D0OP,Autosave,OFF,ON;",
 	"-;",
 
-	"OA,Region,US/UE,Japan;",
-	"OB,BIOS,Enable,Disable;",
-	"OF,Disable mapper,No,Yes;",
+	"H8OA,Region,US/UE,Japan;",
+	"H8OB,BIOS,Enable,Disable;",
+	"H8OF,Disable mapper,No,Yes;",
+	"H7o12,VDPs,Both,2,1,None;",
+	"H7o34,PSGs,Both,2,1,None;",
 	"-;",
 
 	"P1,Audio & Video;",
@@ -262,9 +266,9 @@ parameter CONF_STR = {
 
 	"-;",
 	"R0,Reset;",
-	"J1,Fire 1,Fire 2,Pause;",
-	"jn,A|P,B,Start;",
-	"jp,Y|P,A,Start;",
+	"J1,Fire 1,Fire 2,Pause,Coin;",
+	"jn,A|P,B,Start,Coin;",
+	"jp,Y|P,A,Start,Coin;",
 	"V,v",`BUILD_DATE
 };
 
@@ -285,10 +289,12 @@ pll pll
 wire reset = RESET | status[0] | buttons[1] | cart_download | bk_loading;
 
 //////////////////   HPS I/O   ///////////////////
-wire  [6:0] joy[4], joy_0, joy_1;
+wire [15:0] joy_0, joy_1, joy_2, joy_3;
+wire  [7:0] joy[4];
 wire  [7:0] joy0_x,joy0_y,joy1_x,joy1_y;
 wire  [7:0] paddle_0, paddle_1;
 wire  [1:0] buttons;
+wire [10:0] ps2_key;
 wire [63:0] status;
 
 wire        ioctl_wr;
@@ -324,16 +330,17 @@ hps_io #(.STRLEN($size(CONF_STR)>>3), .WIDE(0)) hps_io
 
 	.joystick_0(joy_0),
 	.joystick_1(joy_1),
-	.joystick_2(joy[2]),
-	.joystick_3(joy[3]),
+	.joystick_2(joy_2),
+	.joystick_3(joy_3),
 	.joystick_analog_0({joy0_y, joy0_x}),
 	.joystick_analog_1({joy1_y, joy1_x}),
 	.paddle_0(paddle_0),
 	.paddle_1(paddle_1),
 
 	.buttons(buttons),
+	.ps2_key(ps2_key),
 	.status(status),
-	.status_menumask({en216p,status[13],~gun_en,~raw_serial,gg,~gg_avail,~bk_ena}),
+	.status_menumask({systeme,~dbg_menu,en216p,status[13],~gun_en,~raw_serial,gg,~gg_avail,~bk_ena}),
 	.forced_scandoubler(forced_scandoubler),
 	.new_vmode(pal),
 	.gamma_bus(gamma_bus),
@@ -371,7 +378,18 @@ wire        ram_rd;
 
 wire code_index = &ioctl_index;
 wire code_download = ioctl_download & code_index;
-wire cart_download = ioctl_download & ~code_index;
+wire cart_download = ioctl_download & ~(|ioctl_index[7:2]);
+
+// SYSMODE[0]: [0]=EncryptBase,[1]=EncryptBank,[2]=Paddle,[3]=Pedal,[4,5]=E0Type,[6]=E1,[7]=E2
+// SYSMODE[1]: [0]=
+reg [7:0] SYSMODE[1];
+reg [7:0] DSW[3];
+always @(posedge clk_sys) begin
+	if (ioctl_wr) begin
+		if ((ioctl_index==4  ) && !ioctl_addr[24:1]) SYSMODE[ioctl_addr[0]] <= ioctl_dout;
+		if ((ioctl_index==254) && !ioctl_addr[24:2]) DSW[ioctl_addr[1:0]] <= ioctl_dout;
+	end
+end
 
 sdram ram
 (
@@ -379,7 +397,7 @@ sdram ram
 
 	.init(~locked),
 	.clk(clk_sys),
-	.clkref(ce_cpu),
+	.clkref(systeme ? ce_pix : ce_cpu),
 
 	.waddr(romwr_a),
 	.din(ioctl_dout),
@@ -487,6 +505,7 @@ always @(posedge clk_sys) begin
 end
 
 reg gg = 0;
+reg systeme = 0;
 reg [21:0] cart_mask, cart_mask512;
 reg cart_sz512;
 
@@ -500,13 +519,17 @@ always @(posedge clk_sys) begin
 		if(!ioctl_addr) cart_mask <= 0;
 		if(ioctl_addr == 512) cart_mask512 <= 0;
 		gg <= ioctl_index[4:0] == 2;	
+		systeme <= ioctl_index[4:0] == 3;	
 	end;
 	if (old_download & ~cart_download) begin
 		cart_sz512 <= ioctl_addr[9];
 	end;
+	if (ioctl_wr & (ioctl_index==4)) begin
+		systeme <= 1'b1;;
+	end;
 end
 
-wire [12:0] ram_a;
+wire [13:0] ram_a;
 wire        ram_we;
 wire  [7:0] ram_d;
 wire  [7:0] ram_q;
@@ -524,7 +547,8 @@ system #(63) system
 	.ce_pix(ce_pix),
 	.ce_sp(ce_sp),
 	.gg(gg),
-	.bios_en(~status[11]),
+	.systeme(systeme),
+	.bios_en(~status[11] & ~systeme),
 
 	.RESET_n(~reset),
 
@@ -544,6 +568,8 @@ system #(63) system
 	.j1_tl(joya[4]),
 	.j1_tr(joya[5]),
 	.j1_th(joya_th),
+	.j1_start(swap ? joy_1[11] : joy_0[11]),
+	.j1_coin(swap ? joy_1[10] : joy_0[10]),
 
 	.j2_up(joyb[3]),
 	.j2_down(joyb[2]),
@@ -553,12 +579,27 @@ system #(63) system
 	.j2_tr(joyb[5]),
 	.j2_th(joyb_th),
 	.pause(joya[6]&joyb[6]),
+	.j2_start(swap ? joy_0[11] : joy_1[11]),
+	.j2_coin(swap ? joy_0[10] : joy_1[10]),
 
 	.j1_tr_out(joya_tr_out),
 	.j1_th_out(joya_th_out),
 	.j2_tr_out(joyb_tr_out),
 	.j2_th_out(joyb_th_out),
 
+	.E0Type(SYSMODE[0][5:4]),
+	.E1Use(SYSMODE[0][6]),
+	.E2Use(SYSMODE[0][7]),
+	.F2(DSW[0]),
+	.F3(DSW[1]),
+	.E0(DSW[2]),
+
+	.has_pedal(SYSMODE[0][3]),
+	.has_paddle(SYSMODE[0][2]),
+	.paddle(paddle),
+	.paddle2(paddle2),
+	.pedal(pedal),
+		
 	.x(x),
 	.y(y),
 	.color(color),
@@ -569,7 +610,9 @@ system #(63) system
 	.smode_M3(smode_M3),
 	.pal(pal),
 	.region(status[10]),
-	.mapper_lock(status[15]),
+	.mapper_lock(status[15] && ~systeme),
+	.vdp_enables(dbg_menu ? status[34:33] : 2'b00),
+	.psg_enables(dbg_menu ? status[36:35] : 2'b00),
 
 	.fm_ena(~status[12] | gg),
 	.audioL(audio_l),
@@ -586,19 +629,43 @@ system #(63) system
 	.nvram_a(nvram_a),
 	.nvram_we(nvram_we),
 	.nvram_d(nvram_d),
-	.nvram_q(nvram_q)
+	.nvram_q(nvram_q),
+	
+	.encrypt(SYSMODE[0][1:0]),
+	.key_a(key_a),
+	.key_d(key_d)
+	
 );
 
-assign joy[0] = status[1] ? joy_1 : joy_0;
-assign joy[1] = status[1] ? joy_0 : joy_1;
+wire [12:0] key_a;
+wire [7:0] key_d;
+
+wire [12:0] encrypt_a;
+
+wire encrypt_range = ioctl_addr[24:13]==12'b0_0000_0100_100;
+assign encrypt_a = (ioctl_download && encrypt_range) ? ioctl_addr[12:0] : key_a;
+
+spram #(.widthad_a(13)) encrypt_key
+(
+	.clock(clk_sys),
+	.wren(ioctl_wr && encrypt_range),
+	.data(ioctl_dout),
+	.address(encrypt_a),
+	.q(key_d)
+);
+
+assign joy[0] = status[1] ? joy_1[7:0] : joy_0[7:0];
+assign joy[1] = status[1] ? joy_0[7:0] : joy_1[7:0];
+assign joy[2] = joy_2[7:0];
+assign joy[3] = joy_3[7:0];
 
 wire raw_serial = status[16];
 wire pause_combo = status[17];
 wire swap = status[1];
 
-wire [6:0] joya;	
-wire [6:0] joyb;
-wire [6:0] joyser;
+wire [7:0] joya;	
+wire [7:0] joyb;
+wire [7:0] joyser;
 
 wire      joya_tr_out;
 wire      joya_th_out;
@@ -608,6 +675,13 @@ wire      joya_th;
 wire      joyb_th;
 wire      joyser_th;
 reg [1:0] jcnt = 0;
+
+wire has_pedal = SYSMODE[0][3];
+wire [7:0] pedal = paddle_en ? paddle_1 : !joy0_y[7] ? 8'h00: {~joy0_y[6:0],~joy0_y[6]};
+wire [7:0] paddlein = paddle_en ? paddle_0 : has_pedal ? {~joy0_x[7],joy0_x[6:0]} : {joy0_x[7],joy0_x[7],joy0_x[7],joy0_x[7],joy0_x[7],joy0_x[7:5]};
+wire [7:0] paddle2 = paddle_en ? paddle_1 : joy1_x;
+wire [7:0] pedallimit = paddlein[7:5]==3'b111 ? 8'hE0 : paddlein[7:5]==3'b000 ? 8'h20 : paddlein;
+wire [7:0] paddle = has_pedal ? pedallimit : paddlein;
 
 always @(posedge clk_sys) begin
 	reg old_th;
@@ -627,6 +701,7 @@ always @(posedge clk_sys) begin
 			tmr <= 57000;
 		end
 		joyser[6] <= !tmr;
+		joyser[7] <= 1'b0;
 		
 		joya <= swap ? ~joy[1] : joyser;
 		joyb <= swap ? joyser : ~joy[0];	
@@ -637,7 +712,7 @@ always @(posedge clk_sys) begin
 
 	end else begin
 		joya <= ~joy[jcnt];
-		joyb <= status[14] ? 7'h7F : ~joy[1];
+		joyb <= status[14] ? 8'hFF : ~joy[1];
 		joya_th <=  1'b1;
 		joyb_th <=  1'b1;
 				
@@ -662,10 +737,10 @@ always @(posedge clk_sys) begin
 	if(gun_en) begin
 		if(gun_port) begin
 			joyb_th <= ~gun_sensor;
-			joyb <= {2'b11, ~gun_trigger ,4'b1111};
+			joyb <= {3'b111, ~gun_trigger ,4'b1111};
 		end else begin
 			joya_th <= ~gun_sensor;
-			joya <= {2'b11, ~gun_trigger ,4'b1111};
+			joya <= {3'b111, ~gun_trigger ,4'b1111};
 			joyb <= raw_serial ? joyser : ~joy[0];
 			joyb_th <= raw_serial ? joyser_th : 1'b1;
 		end
@@ -677,10 +752,10 @@ always @(posedge clk_sys) begin
 	end
 end
 
-spram #(.widthad_a(13)) ram_inst
+spram #(.widthad_a(14)) ram_inst
 (
 	.clock     (clk_sys),
-	.address   (ram_a),
+	.address   (systeme ? ram_a : {1'b0,ram_a[12:0]}),
 	.wren      (ram_we),
 	.data      (ram_d),
 	.q         (ram_q)
@@ -884,7 +959,7 @@ lightgun lightgun
 
 	.JOY_X(gun_mode[0] ? joy0_x : joy1_x),
 	.JOY_Y(gun_mode[0] ? joy0_y : joy1_y),
-	.JOY(gun_mode[0] ? joy_0 : joy_1),
+	.JOY(gun_mode[0] ? joy_0[7:0] : joy_1[7:0]),
 
 	.HDE(~HBlank),
 	.VDE(~VBlank),
@@ -963,6 +1038,25 @@ always_ff @(posedge clk_sys) begin
 	if (cnt_en16khz == 3355) cnt_en16khz <= 0;
 end
 assign en16khz = cnt_en16khz == 0;
+
+reg dbg_menu = 0;
+always @(posedge clk_sys) begin
+	reg old_stb;
+	reg enter = 0;
+	reg esc = 0;
+	
+	old_stb <= ps2_key[10];
+	if(old_stb ^ ps2_key[10]) begin
+		if(ps2_key[7:0] == 'h5A) enter <= ps2_key[9];
+		if(ps2_key[7:0] == 'h76) esc   <= ps2_key[9];
+	end
+	
+	if(enter & esc) begin
+		dbg_menu <= ~dbg_menu;
+		enter <= 0;
+		esc <= 0;
+	end
+end
 
 endmodule
 

--- a/files.qip
+++ b/files.qip
@@ -1,6 +1,7 @@
 set_global_assignment -name QIP_FILE rtl/T80/T80.qip
 set_global_assignment -name QIP_FILE rtl/VM2413/OPLL.qip
 set_global_assignment -name QIP_FILE rtl/jt89/jt89.qip
+set_global_assignment -name VERILOG_FILE rtl/MC8123.v
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/compressor.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/sdram.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/cheatcodes.sv

--- a/releases/Astro Flash (Japan).mra.missingkey
+++ b/releases/Astro Flash (Japan).mra.missingkey
@@ -1,0 +1,50 @@
+<misterromdescription>
+	<name>Astro Flash (Japan) Broken - No key</name>
+	<setname>astrofl</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>2</players>
+	<joystick>8-way</joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="Fire/Button1,Transform/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="1 Player Only" bits="8" ids="Off,On"/>
+		<dip name="Demo Sounds" bits="9" ids="Off,On"/>
+		<dip name="Lives" bits="10,11" ids="Infinite (Cheat),5,4,3"/>
+		<dip name="Bonus_Life" bits="12,13" ids="50k, 150k and 250k,30k, 80k, 130k and 180k,10k, 30k, 50k and 70k,20k, 60k, 100k and 140k"/>
+		<dip name="Difficulty" bits="14,15" ids="Hardest,Easy,Hard,Medium"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="transfrm.zip" type="merged" md5="2bc658193e8e93f4d7991694547a875f">
+		<!-- banks, size: 0x40000 -->
+		<part crc="DF0F639F" name="epr-7347.ic5"/>
+		<part crc="0F38EA96" name="epr-7348.ic4"/>
+		<part crc="F8C352D5" name="epr-7349.ic3"/>
+		<part crc="0052165D" name="epr-7350.ic2"/>
+		<part crc="DF0F639F" name="epr-7347.ic5"/>
+		<part crc="0F38EA96" name="epr-7348.ic4"/>
+		<part crc="F8C352D5" name="epr-7349.ic3"/>
+		<part crc="0052165D" name="epr-7350.ic2"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="66061137" name="epr-7605.ic7"/>
+
+		<!-- key, size: 0x2000 -->
+		<part crc="FFFFFFFF" name="317-missing.key"/>
+	</rom>
+	<rom index="4">
+		<part>41</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Fantasy Zone II - The Tears of Opa-Opa.mra
+++ b/releases/Fantasy Zone II - The Tears of Opa-Opa.mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+	<name>Fantasy Zone II - The Tears of Opa-Opa (MC-8123, 317-0057)</name>
+	<setname>fantzn2</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>1</players>
+	<joystick>8-way</joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="Fire/Button1,Bomb/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="Demo Sounds" bits="9" ids="Off,On"/>
+		<dip name="Lives" bits="10,11" ids="2,5,4,3"/>
+		<dip name="Timer" bits="12,13" ids="90,80,70,60"/>
+		<dip name="Difficulty" bits="14,15" ids="Hardest,Hard,Easy,Normal"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="fantzn2.zip" type="merged" md5="b2a30dbfbf4547642bd33b538a978096">
+		<!-- banks, size: 0x40000 -->
+		<part crc="57B45681" name="epr-11415.ic5"/>
+		<part crc="A231DC85" name="epr-11413.ic3"/>
+		<part crc="6F7A9F5F" name="epr-11414.ic4"/>
+		<part crc="B14DB5AF" name="epr-11412.ic2"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="76DB7B7B" name="epr-11416.ic7"/>
+
+		<!-- key, size: 0x2000 -->
+		<part crc="EE43D0F0" name="317-0057.key"/>
+	</rom>
+	<rom index="4">
+		<part>41</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Hang On Jr.mra
+++ b/releases/Hang On Jr.mra
@@ -1,0 +1,44 @@
+<misterromdescription>
+	<name>Hang-On Jr. (Rev. B)</name>
+	<setname>hangonjr</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>1</players>
+	<joystick></joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="-,-,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="Enemies" bits="9,10" ids="Hardest,Hard,Medium,Easy"/>
+		<dip name="Time Adj." bits="11,12" ids="Hardest,Hard,Medium,Easy"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="hangonjr.zip" type="merged" md5="e395445f4b1f33cc2a46710974495bda">
+		<!-- banks, size: 0x40000 -->
+		<part crc="EE3CAAB3" name="epr-7258.ic5"/>
+		<part crc="D2BA9BC9" name="epr-7259.ic4"/>
+		<part crc="E14DA070" name="epr-7260.ic3"/>
+		<part crc="3810CBF5" name="epr-7261.ic2"/>
+		<part crc="EE3CAAB3" name="epr-7258.ic5"/>
+		<part crc="D2BA9BC9" name="epr-7259.ic4"/>
+		<part crc="E14DA070" name="epr-7260.ic3"/>
+		<part crc="3810CBF5" name="epr-7261.ic2"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="D63925A7" name="epr-7257b.ic7"/>
+	</rom>
+	<rom index="4">
+		<part>3C</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Opa Opa (Rev A, unprotected).mra
+++ b/releases/Opa Opa (Rev A, unprotected).mra
@@ -1,0 +1,46 @@
+<misterromdescription>
+	<name>Opa Opa (Rev A, unprotected)</name>
+	<setname>opaopan</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>1</players>
+	<joystick>8-way</joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="Fire1/Button1,Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="2"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="Demo Sounds" bits="9" ids="Off,On"/>
+		<dip name="Lives" bits="10,11" ids="2,5,4,3"/>
+		<dip name="Bonus_Life" bits="12,13" ids="None,50k and 90k,25k, 45k and 70k,40k, 60k and 90k"/>
+		<dip name="Difficulty" bits="14,15" ids="Hardest,Hard,Easy,Normal"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="opaopa.zip" type="merged" md5="ba808106e6351b3da18f529c8a81713c">
+		<!-- banks, size: 0x40000 -->
+		<part crc="15203A42" name="epr-11022.ic5"/>
+		<part crc="B4E83340" name="epr-11021.ic4"/>
+		<part crc="C51AAD27" name="epr-11020.ic3"/>
+		<part crc="BD0A6248" name="epr-11019.ic2"/>
+		<part crc="15203A42" name="epr-11022.ic5"/>
+		<part crc="B4E83340" name="epr-11021.ic4"/>
+		<part crc="C51AAD27" name="epr-11020.ic3"/>
+		<part crc="BD0A6248" name="epr-11019.ic2"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="101C5C6A" name="epr-11023a.ic7"/>
+	</rom>
+	<rom index="4">
+		<part>C0</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Opa Opa.mra
+++ b/releases/Opa Opa.mra
@@ -1,0 +1,49 @@
+<misterromdescription>
+	<name>Opa Opa</name>
+	<setname>opaopa</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>1</players>
+	<joystick>8-way</joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="Fire1/Button1,Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="2"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="Demo Sounds" bits="9" ids="Off,On"/>
+		<dip name="Lives" bits="10,11" ids="2,5,4,3"/>
+		<dip name="Bonus_Life" bits="12,13" ids="None,50k and 90k,25k, 45k and 70k,40k, 60k and 90k"/>
+		<dip name="Difficulty" bits="14,15" ids="Hardest,Hard,Easy,Normal"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="opaopa.zip" type="merged" md5="0be8f107b47ca34bb22d937ae5987dfd">
+		<!-- banks, size: 0x40000 -->
+		<part crc="6BC41D6E" name="epr-11050.ic5"/>
+		<part crc="395C1D0A" name="epr-11051.ic4"/>
+		<part crc="4CA132A2" name="epr-11052.ic3"/>
+		<part crc="A165E2EF" name="epr-11053.ic2"/>
+		<part crc="6BC41D6E" name="epr-11050.ic5"/>
+		<part crc="395C1D0A" name="epr-11051.ic4"/>
+		<part crc="4CA132A2" name="epr-11052.ic3"/>
+		<part crc="A165E2EF" name="epr-11053.ic2"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="024B1244" name="epr-11054.ic7"/>
+
+		<!-- key, size: 0x2000 -->
+		<part crc="D6312538" name="317-0042.key"/>
+	</rom>
+	<rom index="4">
+		<part>C3</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Riddle of Pythagoras (Japan).mra
+++ b/releases/Riddle of Pythagoras (Japan).mra
@@ -1,0 +1,45 @@
+<misterromdescription>
+	<name>Riddle of Pythagoras (Japan)</name>
+	<setname>ridleofp</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega / Nasco</manufacturer>
+	<players>1</players>
+	<joystick>8-way</joystick>
+	<rotation>vertical (cw)</rotation>
+	<region></region>
+	<buttons names="Launch/Button1,Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="Free Play,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="Free Play,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="Lives" bits="8,9" ids="100 (Cheat),5,4,3"/>
+		<dip name="Difficulty" bits="11" ids="Difficult,Easy"/>
+		<dip name="Bonus_Life" bits="13,14" ids="None,200K 1M 2M 10M 20M 50M,100K 200K 1M 2M 10M 20M 50M,50K 100K 200K 1M 2M 10M 20M 50M"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="ridleofp.zip" type="merged" md5="22cff7d82820707800ed419441475842">
+		<!-- banks, size: 0x40000 -->
+		<part crc="35964109" name="epr-10425.bin"/>
+		<part crc="FCDA1DFA" name="epr-10424.bin"/>
+		<part crc="0B87244F" name="epr-10423.bin"/>
+		<part crc="14781E56" name="epr-10422.bin"/>
+		<part crc="35964109" name="epr-10425.bin"/>
+		<part crc="FCDA1DFA" name="epr-10424.bin"/>
+		<part crc="0B87244F" name="epr-10423.bin"/>
+		<part crc="14781E56" name="epr-10422.bin"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="4404C7E7" name="epr-10426.bin"/>
+	</rom>
+	<rom index="4">
+		<part>04</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Slap Shooter.mra
+++ b/releases/Slap Shooter.mra
@@ -1,0 +1,55 @@
+<misterromdescription>
+	<name>Slap Shooter</name>
+	<setname>slapshtr</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>1</players>
+	<joystick>8-way</joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="Pass/Button1,Shot/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="Unknown0" bits="8" ids="Off,On"/>
+		<dip name="Demo Sounds" bits="9" ids="On,Off"/>
+		<dip name="Unknown2" bits="10" ids="Off,On"/>
+		<dip name="Unknown3" bits="11" ids="Off,On"/>
+		<dip name="Unknown4" bits="12" ids="Off,On"/>
+		<dip name="Unknown5" bits="13" ids="Off,On"/>
+		<dip name="Unknown6" bits="14" ids="Off,On"/>
+		<dip name="Unknown7" bits="15" ids="Off,On"/>
+<!--
+		<dip name="Lives" bits="10,11" ids="2,5,4,3"/>
+		<dip name="Timer" bits="12,13" ids="90,80,70,60"/>
+		<dip name="Difficulty" bits="14,15" ids="Hardest,Hard,Easy,Normal"/>
+-->
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="slapshtr.zip" type="merged" md5="56553344d411ac3dae69f2786e8218f0">
+		<!-- banks, size: 0x40000 -->
+		<part crc="61C938B6" name="epr-7352.ic5"/>
+		<part crc="8EE2951A" name="epr-7353.ic4"/>
+		<part crc="41482AA0" name="epr-7354.ic3"/>
+		<part crc="C67E1AEF" name="epr-7355.ic2"/>
+		<part crc="61C938B6" name="epr-7352.ic5"/>
+		<part crc="8EE2951A" name="epr-7353.ic4"/>
+		<part crc="41482AA0" name="epr-7354.ic3"/>
+		<part crc="C67E1AEF" name="epr-7355.ic2"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="894ADB04" name="epr-7351.ic7"/>
+	</rom>
+	<rom index="4">
+		<part>40</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Tetris (Japan, System E).mra
+++ b/releases/Tetris (Japan, System E).mra
@@ -1,0 +1,44 @@
+<misterromdescription>
+	<name>Tetris (Japan, System E)</name>
+	<setname>tetrisse</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>1</players>
+	<joystick>8-way</joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="Rotate/Button1,Rotate/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="Demo Sounds" bits="9" ids="On,Off"/>
+		<dip name="Difficulty" bits="12,13" ids="Hardest,Hard,Easy,Normal"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="tetrisse.zip" type="merged" md5="5ea87dc49d7dcc026f73a0506b3cf6da">
+		<!-- banks, size: 0x40000 -->
+		<part crc="28B550BF" name="epr-12212.5"/>
+		<part crc="5AA114E9" name="epr-12211.4"/>
+		<part crc="28B550BF" name="epr-12212.5"/>
+		<part crc="5AA114E9" name="epr-12211.4"/>
+		<part crc="28B550BF" name="epr-12212.5"/>
+		<part crc="5AA114E9" name="epr-12211.4"/>
+		<part crc="28B550BF" name="epr-12212.5"/>
+		<part crc="5AA114E9" name="epr-12211.4"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="EF3C7A38" name="epr-12213.7"/>
+	</rom>
+	<rom index="4">
+		<part>C0</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/releases/Transformer.mra
+++ b/releases/Transformer.mra
@@ -1,0 +1,47 @@
+<misterromdescription>
+	<name>Transformer</name>
+	<setname>transfrm</setname>
+	<rbf>SMS</rbf>
+	<mameversion></mameversion>
+	<year></year>
+	<manufacturer>Sega</manufacturer>
+	<players>2</players>
+	<joystick>8-way</joystick>
+	<rotation>horizontal</rotation>
+	<region></region>
+	<buttons names="Fire/Button1,Transform/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<switches base="24" default="FF,FF,FF">
+		<!-- SWA -->
+		<dip name="Coin A" bits="0,3" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<dip name="Coin B" bits="4,7" ids="1/1,1/1 2/3,1/1 4/5,1/1 5/6,2/1 4/3,2/1 5/3 6/4,2/3,4/1,3/1,2/1,1/6,1/5,1/4,1/3,1/2,1/1"/>
+		<!-- SWB -->
+		<dip name="1 Player Only" bits="8" ids="Off,On"/>
+		<dip name="Demo Sounds" bits="9" ids="Off,On"/>
+		<dip name="Lives" bits="10,11" ids="Infinite (Cheat),5,4,3"/>
+		<dip name="Bonus_Life" bits="12,13" ids="50k, 150k and 250k,30k, 80k, 130k and 180k,10k, 30k, 50k and 70k,20k, 60k, 100k and 140k"/>
+		<dip name="Difficulty" bits="14,15" ids="Hardest,Easy,Hard,Medium"/>
+		<!-- SWC -->
+		<dip name="Service Toggle" bits="18" ids="On,Off"/>
+		<dip name="Service Mode" bits="19" ids="On,Off"/>
+	</switches>
+	<rom index="0" zip="transfrm.zip" type="merged" md5="2bc658193e8e93f4d7991694547a875f">
+		<!-- banks, size: 0x40000 -->
+		<part crc="DF0F639F" name="epr-7347.ic5"/>
+		<part crc="0F38EA96" name="epr-7348.ic4"/>
+		<part crc="9D485DF6" name="epr-7606.ic3"/>
+		<part crc="0052165D" name="epr-7350.ic2"/>
+		<part crc="DF0F639F" name="epr-7347.ic5"/>
+		<part crc="0F38EA96" name="epr-7348.ic4"/>
+		<part crc="9D485DF6" name="epr-7606.ic3"/>
+		<part crc="0052165D" name="epr-7350.ic2"/>
+
+		<!-- maincpu, size: 0x8000 -->
+		<part crc="CCF1D123" name="epr-7605.ic7"/>
+	</rom>
+	<rom index="4">
+		<part>40</part>
+	</rom>
+<!--
+	<nvram index="4" size="3"/>
+-->
+</misterromdescription>

--- a/rtl/MC8123.v
+++ b/rtl/MC8123.v
@@ -1,0 +1,327 @@
+// Copyright 2021 by blackwine
+// decryption algorithm based on MAME sources
+
+module MC8123_rom_decrypt
+(
+	input             clk,
+
+	// connect to CPU
+	input             m1,
+	input      [15:0] a,
+	output reg  [7:0] d,
+
+	// connect to program ROM
+	input       [7:0] prog_d,
+
+	// connect to cpu decryption key ROM
+	output     [12:0] key_a,
+	input       [7:0] key_d
+);
+
+assign key_a = {~m1,a[15:10],a[8],a[6],a[4],a[2:0]};
+
+wire [7:0] key = ~key_d;
+
+wire [2:0] decrypt_type = {key[4]^key[5],
+		           key[0]^key[1]^key[2]^key[4],
+	                   key[0]^key[2]^~m1};
+
+wire [1:0] swap = {key[2]^key[3],
+	           key[0]^key[1]};
+
+wire [3:0] param = {key[1]^key[6]^key[7],
+	            key[0]^key[1]^key[6],
+	            key[0]^key[2]^key[3],
+		    key[0]^~m1};
+
+always @( negedge clk ) begin
+	case (decrypt_type)
+		0: d <= decrypt_type_0 (prog_d, param, swap);
+		1: d <= decrypt_type_0 (prog_d, param, swap);
+		2: d <= decrypt_type_1a(prog_d, param, swap);
+		3: d <= decrypt_type_1b(prog_d, param, swap);
+		4: d <= decrypt_type_2a(prog_d, param, swap);
+		5: d <= decrypt_type_2b(prog_d, param, swap);
+		6: d <= decrypt_type_3a(prog_d, param, swap);
+		7: d <= decrypt_type_3b(prog_d, param, swap);
+	endcase
+end
+
+`define bitswap8(a,b,c,d,e,f,g,h) {v[a],v[b],v[c],v[d],v[e],v[f],v[g],v[h]}
+
+reg [7:0] v;
+reg s;
+reg t;
+
+function [7:0] decrypt_type_0;
+	input [7:0] value;
+	input [3:0] p; // param
+	input [1:0] swap;
+
+	v = value;
+	case (swap)
+		0: v = `bitswap8(7,5,3,1,2,0,6,4);
+		1: v = `bitswap8(5,3,7,2,1,0,4,6);
+		2: v = `bitswap8(0,3,4,6,7,1,5,2);
+		3: v = `bitswap8(0,7,3,2,6,4,1,5);
+	endcase
+
+	s = p[3] & v[7];
+	t = p[2] & v[6];
+
+	v = {
+		 v[7] ^ t ^ v[6] ^ p[1],
+		 v[6] ^ (p[1] & (v[7] ^ t ^ v[6])) ^ p[1],
+		 v[5] ^ s ^ v[2] ^ t ^ p[2] ^ p[0],
+		~v[4],
+		~v[3] ^ s,
+		 v[2] ^ t ^ p[2],
+	        ~v[1] ^ t,
+		 v[0] ^ s ^ v[2] ^ t ^ p[2] ^ p[0]
+	};
+
+	decrypt_type_0 = p[0] ? `bitswap8(7,6,5,1,4,3,2,0) : v;
+
+endfunction
+
+// decrypt type 1a
+
+function [7:0] decrypt_type_1a;
+	input [7:0] value;
+	input [3:0] p; // param
+	input [1:0] swap;
+
+	v = value;
+	case (swap)
+		0: v = `bitswap8(4,2,6,5,3,7,1,0);
+		1: v = `bitswap8(6,0,5,4,3,2,1,7);
+		2: v = `bitswap8(2,3,6,1,4,0,7,5);
+		3: v = `bitswap8(6,5,1,3,2,7,0,4);
+	endcase
+
+	v = p[2] ? `bitswap8(7,6,1,5,3,2,4,0) : v;
+
+	v = {
+		 v[7] ^ v[4] ^ p[3],
+		~v[6] ^ v[7] ^ v[2] ^ v[4] ^ p[1],
+		 v[5],
+		 v[4] ^ v[7] ^ v[2],
+		~v[3] ^ v[7] ^ v[6] ^ v[2] ^ p[1],
+		 v[2] ^ v[4] ^ p[3],
+	        ~v[1] ^ v[2],
+		~v[0] ^ v[1]
+	};
+
+	decrypt_type_1a = p[0] ? `bitswap8(7,6,1,4,3,2,5,0) : v;
+endfunction
+
+// decrypt type 1b
+
+function [7:0] decrypt_type_1b;
+	input [7:0] value;
+	input [3:0] p; // param
+	input [1:0] swap;
+
+	v = value;
+	case (swap)
+		0: v = `bitswap8(1,0,3,2,5,6,4,7);
+		1: v = `bitswap8(2,0,5,1,7,4,6,3);
+		2: v = `bitswap8(6,4,7,2,0,5,1,3);
+		3: v = `bitswap8(7,1,3,6,0,2,5,4);
+	endcase
+
+	s = v[2] & v[0];
+	v = {
+		 v[7] ^ s ^ v[5] ^ v[3] ^ p[2],
+		~v[6] ^ v[4] ^ s ^ v[0] ^ v[3] ^ p[2] ^ p[0],
+		 v[5] ^ v[4] ^ s ^ v[1],
+		~v[4] ^ s ^ p[3] ^ p[1],
+		 v[3] ^ p[1] ^ p[2],
+		 v[2] ^ v[7] ^ s ^ v[5] ^ v[0] ^ v[3] ^ p[0],
+	         v[1] ^ v[6] ^ v[0] ^ v[3] ^ p[3] ^ p[0],
+		~v[0] ^ v[3] ^ p[0] ^ p[2]
+	};
+
+	decrypt_type_1b = v;
+endfunction
+
+// decrypt type 2a
+
+function [7:0] decrypt_type_2a;
+	input [7:0] value;
+	input [3:0] p; // param
+	input [1:0] swap;
+
+	v = value;
+	case (swap)
+		0: v = `bitswap8(0,1,4,3,5,6,2,7);
+		1: v = `bitswap8(6,3,0,5,7,4,1,2);
+		2: v = `bitswap8(1,6,4,5,0,3,7,2);
+		3: v = `bitswap8(4,6,7,5,2,3,1,0);
+	endcase
+
+	v = (v[3] || (p[1] & v[2])) ? `bitswap8(6,0,7,4,3,2,1,5) : v;
+	v = {
+		~v[7] ^ v[5],
+		~v[6] ^ v[0],
+		~v[5] ^ v[6],
+		~v[4] ^ p[2],
+		 v[3] ^ v[4] ^ p[2],
+		 v[2] ^ v[1] ^ p[2],
+	        ~v[1] ^ p[2],
+		 v[0] ^ v[4] ^ p[2]
+	};
+
+	case({p[3],p[0]})
+		1: v = `bitswap8(7,6,5,2,1,3,4,0);
+		2: v = `bitswap8(7,6,5,1,2,4,3,0);
+		3: v = `bitswap8(7,6,5,3,4,1,2,0);
+		default:;
+	endcase
+
+	decrypt_type_2a = v;
+endfunction
+
+// decrypt type 2b
+
+function [7:0] decrypt_type_2b;
+	input [7:0] value;
+	input [3:0] p; // param
+	input [1:0] swap;
+
+	v = value;
+	case (swap)
+		0: v = `bitswap8(1,3,4,6,5,7,0,2);
+		1: v = `bitswap8(0,1,5,4,7,3,2,6);
+		2: v = `bitswap8(3,5,4,1,6,2,0,7);
+		3: v = `bitswap8(5,2,3,0,4,7,6,1);
+	endcase
+
+	s = v[7] & v[3];
+	v = {
+		v[7] ^ v[5] ^ s ^ v[4],
+		v[6] ^ s,
+		v[5] ^ v[1] ^ s ^ v[4],
+		v[4] ^ s,
+		v[3] ^ v[5] ^ s ^ v[4],
+		v[2] ^ v[7],
+	        v[1] ^ s ^ v[4],
+		v[0] ^ s
+	};
+
+	s = v[5] & (v[7] ^ v[1]);
+	v = {
+		~v[7] ^ v[6] ^ v[3] ^ p[2] ^ p[1],
+		 v[6] ^ v[3] ^ p[3] ^ p[2],
+		 v[5] ^ v[6] ^ v[3] ^ p[2] ^ p[0],
+		 v[4] ^ s,
+		~v[3] ^ v[2] ^ p[3] ^ p[2],
+		~v[2] ^ p[2] ^ p[0],
+	        ~v[1] ^ v[3] ^ v[2] ^ p[3] ^ p[2],
+		 v[0] ^ s
+	};
+	decrypt_type_2b = v;
+
+endfunction
+
+// decrypt type 3a
+
+function [7:0] decrypt_type_3a;
+	input [7:0] value;
+	input [3:0] p; // param
+	input [1:0] swap;
+
+	v = value;
+	case (swap)
+		0: v = `bitswap8(5,3,1,7,0,2,6,4);
+		1: v = `bitswap8(3,1,2,5,4,7,0,6);
+		2: v = `bitswap8(5,6,1,2,7,0,4,3);
+		3: v = `bitswap8(5,6,7,0,4,2,1,3);
+	endcase
+
+	v = {
+		v[7] ^ v[2],
+		v[6],
+		v[5] ^ v[2],
+		v[4] ^ v[2],
+		v[3],
+		v[2],
+	        v[1],
+		v[0] ^ v[3]
+	};
+
+	v = p[0] ? `bitswap8(7,2,5,4,3,1,0,6) : v;
+
+	v = {
+		v[7],
+		v[6] ^ v[1],
+		v[5],
+		v[4] ^ v[3] ^ p[3],
+		v[3] ^ p[3],
+		v[2] ^ v[3],
+	        v[1] ^ v[3],
+		v[0] ^ v[1]
+	};
+
+	v = v[3] ? `bitswap8(5,6,7,4,3,2,1,0) : v;
+
+	v = {
+		 v[7] ^ p[2],
+		~v[6],
+		~v[5],
+		~v[4] ^ p[1],
+		~v[3],
+		 v[2] ^ v[5],
+	         v[1] ^ v[5],
+		 v[0] ^ p[0]
+	};
+	decrypt_type_3a = v;
+endfunction
+
+
+// decrypt type 3b
+
+function [7:0] decrypt_type_3b;
+	input [7:0] value;
+	input [3:0] p; // param
+	input [1:0] swap;
+
+	v = value;
+	case (swap)
+		0: v = `bitswap8(3,7,5,4,0,6,2,1);
+		1: v = `bitswap8(7,5,4,6,1,2,0,3);
+		2: v = `bitswap8(7,4,3,0,5,1,6,2);
+		3: v = `bitswap8(2,6,4,1,3,7,0,5);
+	endcase
+
+	v = (v[2] ^ v[7]) ? `bitswap8(7,6,3,4,5,2,1,0) : v;
+
+	s = v[2] ^ p[3];
+	t = v[4] ^ v[1];
+	v = {
+		v[7] ^ s ^ p[3],
+		v[6] ^ t,
+		v[5],
+		v[4] ^ v[1],
+		v[3],
+		v[2] ^ v[1],
+	        v[1] ^ ((v[7] ^ s) & (v[6] ^ t) ^ v[7] ^ s),
+		v[0] ^ p[2]
+	};
+
+	v = p[3] ? `bitswap8(4,6,3,2,5,0,1,7) : v;
+	v = {
+		 v[7] ^ p[1],
+		 v[6],
+		~v[5],
+		 v[4] ^ v[5],
+		~v[3] ^ p[0],
+		~v[2] ^ v[7],
+	         v[1] ^ v[4],
+		 v[0]
+	};
+
+	decrypt_type_3b = v;
+endfunction
+
+endmodule

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -17,6 +17,7 @@ entity system is
 		ce_pix:		in	 STD_LOGIC; 
 		ce_sp:		in	 STD_LOGIC;
 		gg:			in	 STD_LOGIC;
+		systeme:		in  STD_LOGIC;
 		-- sg:			in	 STD_LOGIC;		-- sg1000
 		bios_en:	in	 STD_LOGIC;
 
@@ -38,6 +39,8 @@ entity system is
 		j1_tl:		in	 STD_LOGIC;
 		j1_tr:		in	 STD_LOGIC;
 		j1_th:		in  STD_LOGIC;
+		j1_start:	in  STD_LOGIC;
+		j1_coin:		in  STD_LOGIC;
 		j2_up:		in	 STD_LOGIC;
 		j2_down:		in	 STD_LOGIC;
 		j2_left:		in	 STD_LOGIC;
@@ -45,7 +48,22 @@ entity system is
 		j2_tl:		in	 STD_LOGIC;
 		j2_tr:		in	 STD_LOGIC;
 		j2_th:		in  STD_LOGIC;
+		j2_start:	in  STD_LOGIC;
+		j2_coin:		in  STD_LOGIC;
 		pause:		in	 STD_LOGIC;
+		
+		E0Type:	in  STD_LOGIC_VECTOR(1 downto 0);
+		E1Use:	in	 STD_LOGIC;
+		E2Use:	in	 STD_LOGIC;
+		E0:		in  STD_LOGIC_VECTOR(7 downto 0);
+		F2:		in  STD_LOGIC_VECTOR(7 downto 0);
+		F3:		in  STD_LOGIC_VECTOR(7 downto 0);
+
+		has_paddle:	in  STD_LOGIC;
+		has_pedal:	in  STD_LOGIC;
+		paddle:		in  STD_LOGIC_VECTOR(7 downto 0);
+		paddle2:		in  STD_LOGIC_VECTOR(7 downto 0);
+		pedal:		in  STD_LOGIC_VECTOR(7 downto 0);
 
 		j1_tr_out:	out STD_LOGIC;
 		j1_th_out:	out STD_LOGIC;
@@ -63,6 +81,8 @@ entity system is
 		pal:				in STD_LOGIC;
 		region:			in	STD_LOGIC;
 		mapper_lock:	in STD_LOGIC;
+		vdp_enables:	in STD_LOGIC_VECTOR(1 downto 0);
+		psg_enables:	in STD_LOGIC_VECTOR(1 downto 0);
 
 		audioL:		out STD_LOGIC_VECTOR(15 downto 0);
 		audioR:		out STD_LOGIC_VECTOR(15 downto 0);
@@ -72,7 +92,7 @@ entity system is
 		sp64:			in  STD_LOGIC;
 
 		-- Work RAM
-		ram_a:      out STD_LOGIC_VECTOR(12 downto 0);
+		ram_a:      out STD_LOGIC_VECTOR(13 downto 0);
 		ram_d:      out STD_LOGIC_VECTOR( 7 downto 0);
 		ram_we:     out STD_LOGIC;
 		ram_q:      in  STD_LOGIC_VECTOR( 7 downto 0);
@@ -81,7 +101,13 @@ entity system is
 		nvram_a:    out STD_LOGIC_VECTOR(14 downto 0);
 		nvram_d:    out STD_LOGIC_VECTOR( 7 downto 0);
 		nvram_we:   out STD_LOGIC;
-		nvram_q:    in  STD_LOGIC_VECTOR( 7 downto 0)
+		nvram_q:    in  STD_LOGIC_VECTOR( 7 downto 0);
+
+		-- MC8123 decryption
+		encrypt:		in  STD_LOGIC_VECTOR(1 downto 0);
+		key_a : 		out STD_LOGIC_VECTOR(12 downto 0);
+		key_d : 		in  STD_LOGIC_VECTOR(7 downto 0)
+
 	);
 end system;
 
@@ -97,11 +123,21 @@ architecture Behavioral of system is
 	signal D_in:				std_logic_vector(7 downto 0);
 	signal D_out:				std_logic_vector(7 downto 0);
 	signal last_read_addr:  std_logic_vector(15 downto 0);
+	signal ce_z80:				std_logic;
 	
 	signal vdp_RD_n:			std_logic;
 	signal vdp_WR_n:			std_logic;
 	signal vdp_D_out:			std_logic_vector(7 downto 0);
-	
+	signal vdp_IRQ_n:			std_logic;
+	signal vdp_color:			std_logic_vector(11 downto 0);
+	signal vdp_y1:				std_logic;
+	signal vdp2_RD_n:			std_logic;
+	signal vdp2_WR_n:			std_logic;
+	signal vdp2_D_out:		std_logic_vector(7 downto 0);
+	signal vdp2_IRQ_n:		std_logic;
+	signal vdp2_color:		std_logic_vector(11 downto 0);
+	signal vdp2_y1:			std_logic;
+
 	signal ctl_WR_n:			std_logic;
 	
 	signal io_RD_n:			std_logic;
@@ -110,7 +146,10 @@ architecture Behavioral of system is
 	
 	signal ram_WR:				std_logic;
 	signal ram_D_out:			std_logic_vector(7 downto 0);
-	
+
+	signal vram_WR:			std_logic;
+	signal vram2_WR:			std_logic;
+
 	signal boot_rom_D_out:	std_logic_vector(7 downto 0);
 	
 	signal bootloader_n:	std_logic := '0';
@@ -122,17 +161,31 @@ architecture Behavioral of system is
 	signal bank2:				std_logic_vector(7 downto 0) := "00000010";
 	signal bank3:				std_logic_vector(7 downto 0) := "00000011";
   
+	signal vdp_se_bank:		std_logic := '0';
+	signal vdp2_se_bank:		std_logic := '0';
+	signal vdp_cpu_bank:		std_logic := '0';
+	signal rom_bank:			std_logic_vector(3 downto 0) := "0000";
+
 	signal PSG_outL:			std_logic_vector(10 downto 0);
 	signal PSG_outR:			std_logic_vector(10 downto 0);
 	signal PSG_mux:			std_logic_vector(7 downto 0);
 	signal psg_WR_n:			std_logic;
 	signal bal_WR_n:			std_logic;
+	signal PSG2_outL:			std_logic_vector(10 downto 0);
+	signal PSG2_outR:			std_logic_vector(10 downto 0);
+	signal psg2_WR_n:			std_logic;
+	signal bal2_WR_n:			std_logic;
 
 	signal FM_out:				std_logic_vector(13 downto 0);
 	signal FM_gated:			std_logic_vector(12 downto 0);
 	alias FM_sign:				std_logic is FM_out(13);
 	alias FM_adj:				std_logic is FM_out(12);
 	signal fm_WR_n:	   	std_logic;
+
+	signal mix_inL:			std_logic_vector(12 downto 0);
+	signal mix_inR:			std_logic_vector(12 downto 0);
+	signal mix2_inL:			std_logic_vector(12 downto 0);
+	signal mix2_inR:			std_logic_vector(12 downto 0);
 	
 	signal det_D:		   	std_logic_vector(2 downto 0);
 	signal det_WR_n:	   	std_logic;
@@ -158,6 +211,8 @@ architecture Behavioral of system is
 	signal mapper_msx_lock :   boolean := false ;
 	signal mapper_msx :		   std_logic := '0' ;
 
+	signal mc8123_D_out : std_logic_vector(7 downto 0);
+
 	signal GENIE		: boolean;
 	signal GENIE_DO	: std_logic_vector(7 downto 0);
 	signal GENIE_DI   : std_logic_vector(7 downto 0);
@@ -179,6 +234,20 @@ architecture Behavioral of system is
 			genie_data  : out std_logic_vector(7 downto 0)
 		);
 	end component;
+	
+	COMPONENT MC8123_rom_decrypt IS
+	PORT (
+		clk    : IN  STD_LOGIC;
+		m1     : IN  STD_LOGIC;
+		a      : IN  STD_LOGIC_VECTOR(15 downto 0);
+		d      : OUT STD_LOGIC_VECTOR(7 downto 0);
+		prog_d : IN STD_LOGIC_VECTOR(7 downto 0);
+		key_a  : OUT STD_LOGIC_VECTOR(12 downto 0);
+		key_d  : IN STD_LOGIC_VECTOR(7 downto 0)
+	);
+	END COMPONENT;
+
+	
 begin
 
 	-- Game Genie
@@ -209,7 +278,7 @@ begin
 	(
 		RESET_n	=> RESET_n,
 		CLK		=> clk_sys,
-		CEN		=> ce_cpu,
+		CEN		=> ce_z80,
 		INT_n		=> IRQ_n,
 		NMI_n		=> pause or gg,
 		MREQ_n	=> MREQ_n,
@@ -236,19 +305,58 @@ begin
 		HL			=> HL,
 		gg			=> gg,
 		-- Bsg			=> sg,		-- sg1000
+		se_bank	=> vdp_se_bank,
 		RD_n		=> vdp_RD_n,
 		WR_n		=> vdp_WR_n,
-		IRQ_n		=> IRQ_n,
+		IRQ_n		=> vdp_IRQ_n,
+		WR_direct => vram_WR,
+		A_direct	=> A(13 downto 8),
 		A			=> A(7 downto 0),
 		D_in		=> D_in,
 		D_out		=> vdp_D_out,
 		x			=> x,
 		y			=> y,
-		color		=> color,
+		color		=> vdp_color,
+		y1       => vdp_y1,
 		smode_M1  => smode_M1,
 		smode_M2  => smode_M2,
 		smode_M3  => smode_M3,
 		mask_column => mask_column,
+		black_column => black_column,
+		reset_n  => RESET_n
+	);
+
+	vdp2_inst: entity work.vdp
+	generic map(
+		MAX_SPPL => MAX_SPPL
+	)
+	port map
+	(
+		clk_sys	=> clk_sys,
+		ce_vdp	=> ce_vdp,
+		ce_pix	=> ce_pix,
+		ce_sp		=> ce_sp,
+		sp64		=> sp64,
+		HL			=> HL,
+		gg			=> gg,
+		-- Bsg			=> sg,		-- sg1000
+		se_bank	=> vdp2_se_bank,
+		RD_n		=> vdp2_RD_n,
+		WR_n		=> vdp2_WR_n,
+		IRQ_n		=> vdp2_IRQ_n,
+		WR_direct => vram2_WR,
+		A_direct	=> A(13 downto 8),
+		A			=> A(7 downto 0),
+		D_in		=> D_in,
+		D_out		=> vdp2_D_out,
+		x			=> x,
+		y			=> y,
+		color		=> vdp2_color,
+		y1       => vdp2_y1,
+--		smode_M1  => smode2_M1,
+--		smode_M2  => smode2_M2,
+--		smode_M3  => smode2_M3,
+--		mask_column => mask2_column,
 		black_column => black_column,
 		reset_n  => RESET_n
 	);
@@ -264,6 +372,21 @@ begin
 		mux		=> PSG_mux,
 		soundL	=> PSG_outL,
 		soundR	=> PSG_outR,
+
+		rst		=> not RESET_n
+	);
+	
+	psg2_inst: jt89
+	port map
+	(
+		clk		=> clk_sys,
+		clk_en   => ce_cpu,
+		wr_n		=> psg2_WR_n,
+		din		=> D_in,
+		
+		mux		=> PSG_mux,
+		soundL	=> PSG2_outL,
+		soundR	=> PSG2_outR,
 
 		rst		=> not RESET_n
 	);
@@ -289,6 +412,11 @@ FM_gated <= (others=>'0') when fm_ena='0' else  -- All zero if FM is disabled
 				FM_out(FM_out'high-1 downto 0) when FM_sign=FM_adj else -- Pass through
 				(FM_gated'high=>FM_sign,others=>FM_adj); -- Clamp
 
+mix_inL <= (others=>'0') when psg_enables(0)='1' else (PSG_outL(10) & PSG_outL & '0') when systeme='1' else (others=>'0');
+mix_inR <= (others=>'0') when psg_enables(0)='1' else (PSG_outR(10) & PSG_outR & '0') when systeme='1' else (others=>'0');
+mix2_inL <= (others=>'0') when psg_enables(1)='1' else (PSG2_outL(10) & PSG2_outL & '0') when systeme='1' else FM_gated;
+mix2_inR <= (others=>'0') when psg_enables(1)='1' else (PSG2_outR(10) & PSG2_outR & '0') when systeme='1' else FM_gated;
+				
 -- The old code shifts FM right by one place and PSG right by three places.
 -- This version shift FM left one place and PSG right by one place, so the volume
 -- is four times higher.  I haven't yet found a game in which this clips.
@@ -297,10 +425,10 @@ mix : entity work.AudioMix
 port map(
 	clk => clk_sys,
 	reset_n => RESET_n,
-	audio_in_l1 => signed((PSG_outL(10) & PSG_outL & "0000")),
-	audio_in_l2 => signed((FM_gated & "000")),
-	audio_in_r1 => signed((PSG_outR(10) & PSG_outR & "0000")),
-	audio_in_r2 => signed((FM_gated & "000")),
+	audio_in_l1 => signed(mix_inL & "000"),
+	audio_in_l2 => signed(mix2_inL & "000"),
+	audio_in_r1 => signed(mix_inR & "000"),
+	audio_in_r2 => signed(mix2_inR & "000"),
 	std_logic_vector(audio_l) => audioL,
 	std_logic_vector(audio_r) => audioR
 );
@@ -320,6 +448,10 @@ port map(
 		D_in		=> D_in,
 		D_out		=> io_D_out,
 		HL_out	=> HL,
+		vdp1_bank => vdp_se_bank,
+		vdp2_bank => vdp2_se_bank,
+		vdp_cpu_bank => vdp_cpu_bank,
+		rom_bank => rom_bank,
 		J1_tr_out => j1_tr_out,
 		J1_th_out => j1_th_out,
 		J2_tr_out => j2_tr_out,
@@ -331,6 +463,8 @@ port map(
 		J1_tl		=> j1_tl,
 		J1_tr		=> j1_tr,
 		J1_th		=> j1_th,
+		J1_start	=> j1_start,
+		J1_coin	=> j1_coin,
 		J2_up		=> j2_up,
 		J2_down	=> j2_down,
 		J2_left	=> j2_left,
@@ -338,14 +472,30 @@ port map(
 		J2_tl		=> j2_tl,
 		J2_tr		=> j2_tr,
 		J2_th		=> j2_th,
+		J2_start	=> j2_start,
+		J2_coin	=> j2_coin,
 		Pause		=> pause,
+		E0Type	=> E0Type,
+		E1Use		=> E1Use,
+		E2Use		=> E2Use,
+		E0			=> E0,
+		F2			=> F2,
+		F3			=> F3,
+		has_paddle=> has_paddle,
+		has_pedal=> has_pedal,
+		paddle	=> paddle,
+		paddle2	=> paddle2,
+		pedal		=> pedal,
 		pal		=> pal,
 		gg			=> gg,
+		systeme	=> systeme,
 		region	=> region,
 		RESET_n	=> RESET_n
 	);
+	
+	ce_z80 <= ce_pix when systeme = '1' else ce_cpu;
 
-	ram_a <= A(12 downto 0);
+	ram_a <= A(13 downto 0) when systeme = '1' else '0' & A(12 downto 0);
 	ram_we <= ram_WR;
 	ram_d <= D_in;
 	ram_D_out <= ram_q;
@@ -367,23 +517,42 @@ port map(
 		address	=> A(13 downto 0),
 		q			=> boot_rom_D_out
 	);
-		
+	
+	mc8123_inst : component MC8123_rom_decrypt
+	port map
+	(
+		clk		=> clk_sys,
+		m1			=> not M1_n,
+		a			=> A,
+		d			=> mc8123_D_out,
+		prog_d	=> rom_do,
+		key_a		=> key_a,
+		key_d		=> key_d
+	);
+
 	-- glue logic
 	bal_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 0)="00000110" and gg='1' else '1';
-	vdp_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="10" else '1';
-	vdp_RD_n <= RD_n when IORQ_n='0' and M1_n='1' and (A(7 downto 6)="01" or A(7 downto 6)="10") else '1';
-	psg_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="01" else '1';
+	vdp_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="10" and (A(2)='0' or systeme='0') else '1';
+	vdp2_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="10" and (A(2)='1' and systeme='1')  else '1';
+	vdp_RD_n <= RD_n when IORQ_n='0' and M1_n='1' and (A(7 downto 6)="01" or A(7 downto 6)="10") and (A(2)='0' or systeme='0') else '1';
+	vdp2_RD_n <= RD_n when IORQ_n='0' and M1_n='1' and (A(7 downto 6)="01" or A(7 downto 6)="10") and (A(2)='1' and systeme='1') else '1';
+	psg_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="01" and (A(2)='0' or systeme='0') else '1';
+	psg2_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="01" and (A(2)='1' and systeme='1') else '1';
 	ctl_WR_n <=	WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="00" and A(0)='0' else '1';
-	io_WR_n  <=	WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 6)="00" and (A(0)='1' or (gg='1' and A(5 downto 3)="000")) else '1';
+	io_WR_n  <=	WR_n when IORQ_n='0' and M1_n='1' and ((A(7 downto 6)="00" and (A(0)='1' or (gg='1' and A(5 downto 3)="000"))) or (A(7 downto 6)="11" and systeme='1')) else '1';
 	io_RD_n  <=	RD_n when IORQ_n='0' and M1_n='1' and (A(7 downto 6)="11" or (gg='1' and A(7 downto 3)="00000" and A(2 downto 1)/="11")) else '1';
 	fm_WR_n  <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 1)="1111000" else '1';
 	det_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 0)=x"F2" else '1';
+	IRQ_n <= vdp_IRQ_n when systeme='0' else vdp2_IRQ_n;
 					
 	ram_WR   <= not WR_n when MREQ_n='0' and A(15 downto 14)="11" else '0';
+	vram_WR  <= not WR_n when MREQ_n='0' and A(15 downto 14)="10" and vdp_cpu_bank='1' and systeme='1' else '0';
+	vram2_WR  <= not WR_n when MREQ_n='0' and A(15 downto 14)="10" and vdp_cpu_bank='0' and systeme='1' else '0';
 	nvram_WR <= not WR_n when MREQ_n='0' and ((A(15 downto 14)="10" and nvram_e = '1') 
 						or (A(15 downto 14)="11" and nvram_ex = '1') 
 						or (A(15 downto 13)="101" and nvram_cme = '1')) else '0';
 	rom_RD   <= not RD_n when MREQ_n='0' and A(15 downto 14)/="11" else '0';
+	color    <= vdp2_color when (vdp2_y1='1' and systeme='1' and vdp_enables(1)='0') else vdp_color when vdp_enables(0)='0' else x"000";
 
 	process (clk_sys)
 	begin
@@ -396,7 +565,7 @@ port map(
 		end if;
 	end process;
 	
-	irom_D_out <=	boot_rom_D_out when bootloader_n='0' and A(15 downto 14)="00" else rom_do;
+	irom_D_out <=	boot_rom_D_out when bootloader_n='0' and A(15 downto 14)="00" else mc8123_D_out when (encrypt(0)='1' and A(15)='0') or (encrypt(1)='1' and A(14)='0') else rom_do;
 	
 	process (clk_sys)
 	begin
@@ -412,11 +581,11 @@ port map(
 		end if;
 	end process;
 	
-	process (IORQ_n,A,vdp_D_out,io_D_out,irom_D_out,ram_D_out,nvram_D_out,
-					nvram_ex,nvram_e,nvram_cme,gg,det_D,fm_ena,bootloader_n)
+	process (IORQ_n,A,vdp_D_out,vdp2_D_out,io_D_out,irom_D_out,ram_D_out,nvram_D_out,
+					nvram_ex,nvram_e,nvram_cme,gg,det_D,fm_ena,bootloader_n,systeme)
 	begin
 		if IORQ_n='0' then
-			if A(7 downto 0)=x"F2" and fm_ena = '1' then
+			if A(7 downto 0)=x"F2" and fm_ena = '1' and systeme='0' then
 				D_out <= "11111"&det_D;
 			elsif (A(7 downto 6)="11" or (gg='1' and A(7 downto 3)="00000" and A(2 downto 0)/="111")) then
 				D_out(6 downto 0) <= io_D_out(6 downto 0);
@@ -426,6 +595,8 @@ port map(
 				else
 					D_out(7) <= io_D_out(7);
 				end if;
+			elsif (A(2)='1' and systeme='1') then
+				D_out <= vdp2_D_out;
 			else
 				D_out <= vdp_D_out;
 			end if;
@@ -498,7 +669,9 @@ port map(
 				if WR_n='1' and MREQ_n='0' then
 					last_read_addr <= A; -- gyurco anti-ldir patch
 				end if;
-				if mapper_msx = '1' then
+				if systeme = '1' then
+					-- no systeme mappers
+				elsif mapper_msx = '1' then
 					if WR_n='0' and A(15 downto 2)="00000000000000" then
 						case A(1 downto 0) is
 							when "00" => bank2 <= D_in;
@@ -565,9 +738,16 @@ port map(
 	end process;
 
 	rom_a(12 downto 0) <= A(12 downto 0);
-	process (A,bank0,bank1,bank2,bank3,mapper_msx,mapper_codies)
+	process (A,bank0,bank1,bank2,bank3,mapper_msx,mapper_codies,systeme,rom_bank)
 	begin
-		if mapper_msx = '1' then
+		if systeme = '1' then
+			case A(15 downto 14) is
+			when "10" =>	
+				rom_a(21 downto 13) <= "0000" & rom_bank & A(13);
+			when others =>
+				rom_a(21 downto 13) <= "000100" & A(15 downto 13);
+			end case;
+		elsif mapper_msx = '1' then
 			case A(15 downto 13) is
 			when "010" =>	
 				rom_a(21 downto 13) <= '0' & bank0;

--- a/rtl/vdp_main.vhd
+++ b/rtl/vdp_main.vhd
@@ -23,6 +23,7 @@ entity vdp_main is
 		y:						in  std_logic_vector(8 downto 0);
 			
 		color:				out std_logic_vector (11 downto 0);
+		y1:               out std_logic;
 					
 		display_on:			in  std_logic;
 		mask_column0:		in  std_logic;
@@ -136,6 +137,7 @@ begin
 		variable spr_active	: boolean;
 		variable bg_active	: boolean;
 	begin
+		y1 <= '1';
 		if ((x>48 and x<=208) or (gg='0' and x<=256 and x>0)) and -- thank you slingshot
  			(mask_column0='0' or x>=9) and display_on='1' then
 			if (((y>=24 and y<168) and smode_M1='0')
@@ -149,6 +151,7 @@ begin
 				if not spr_active and not bg_active then
 					out_color <= overscan ;
 					cram_A <= bg_color(4)&"0000";
+					y1 <= '0';
 				elsif (bg_priority='0' and spr_active) or (bg_priority='1' and not bg_active) then
 					out_color <= spr_color ;
 					cram_A <= "1"&spr_color;


### PR DESCRIPTION
- 8 of 9 games working (Astro Flash appears to not have its encryption key dumped).
- Thanks to Blackwine for the MC8123 decryption code.
- Of the 9 games Astro Flash and Transformer are the same game (Transformer is unencrypted and works), and Opa Opa has both an encrypted and unencrypted versions.  So only 7 unique games.