### PR TITLE
Set Aspect Ratio to 4:3 for Game Gear

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -198,8 +198,8 @@ video_freak video_freak
 (
 	.*,
 	.VGA_DE_IN(vga_de),
-	.ARX((!ar) ? (border ? 12'd47 : 12'd32) : (ar - 1'd1)),
-	.ARY((!ar) ? (border ? 12'd35 : 12'd21) : 12'd0),
+	.ARX((!ar) ? (gg ? 12'd4 : (border ? 12'd47 : 12'd32)) : (ar - 1'd1)),
+	.ARY((!ar) ? (gg ? 12'd3 : (border ? 12'd35 : 12'd21)) : 12'd0),
 	.CROP_SIZE(en216p ? 10'd216 : 10'd0),
 	.CROP_OFF(0),
 	.SCALE(status[31:30])


### PR DESCRIPTION
This switches to 4:3 when a Game Gear game is loaded. This was previously solved in an issue, but when the aspect ratio was corrected for SMS an exception for Game Gear was not retained. The real Game Gear apparently had an unusual display for a handheld in order to accommodate Master System ports.

Real Game Gear (courtesy of Bob from RetroRGB):
![image](https://user-images.githubusercontent.com/16388068/174232475-6678aa45-2205-4c8f-a591-15b1dd9c3741.png)

Before changes (current release):
![Screenshot 2022-06-16 23-40-00](https://user-images.githubusercontent.com/16388068/174232603-1661cc23-aa52-46ea-805f-7bbddb791465.png)

After:
![Screenshot 2022-06-16 23-37-58](https://user-images.githubusercontent.com/16388068/174232419-66df818e-315b-4e58-b811-64ae699d8c08.png)
