### PR TITLE
New 5MHz option for smooth gameplay

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -211,7 +211,7 @@ video_freak video_freak
 // 0         1         2         3          4         5         6   
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXX
 
 `include "build_id.v"
 parameter CONF_STR = {
@@ -232,6 +232,7 @@ parameter CONF_STR = {
 	"H8OA,Region,US/UE,Japan;",
 	"H8OB,BIOS,Enable,Disable;",
 	"H8OF,Disable mapper,No,Yes;",
+	"H8o8,Z80 Speed,3.59MHz,5.385MHz;",
 	"H8-;",
 	"H7o12,VDPs,Both,2,1,None;",
 	"H7o34,PSGs,Both,2,1,None;",
@@ -456,7 +457,7 @@ sdram ram
 
 	.init(~locked),
 	.clk(clk_sys),
-	.clkref(systeme ? ce_pix : ce_cpu),
+	.clkref(systeme ? ce_pix : turbo ? ce_pix : ce_cpu),
 
 	.waddr(romwr_a),
 	.din(ioctl_dout),
@@ -606,6 +607,7 @@ system #(63) system
 	.ce_vdp(ce_vdp),
 	.ce_pix(ce_pix),
 	.ce_sp(ce_sp),
+	.turbo(turbo),
 	.gg(gg),
 	.ggres(ggres),
 	.systeme(systeme),
@@ -848,6 +850,7 @@ wire smode_M1, smode_M2, smode_M3;
 wire pal = status[2];
 wire border = status[13] & ~gg;
 wire ggres = ~status[39] & gg;
+wire turbo = status[40];
 
 video video
 (
@@ -869,6 +872,7 @@ video video
 );
 
 reg ce_cpu;
+reg ce_snd;
 reg ce_vdp;
 reg ce_pix;
 reg ce_sp;

--- a/rtl/oplldelay.vhd
+++ b/rtl/oplldelay.vhd
@@ -1,0 +1,63 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use work.VM2413.ALL;
+entity oplldelay is
+     port(
+        xin         : in  std_logic;
+        xout        : out std_logic;
+        xena        : in  std_logic;
+        delay       : in  std_logic;
+        d           : in  std_logic_vector( 7 downto 0 );
+        a           : in  std_logic;
+        cs_n        : in  std_logic;
+        we_n        : in  std_logic;
+        ic_n        : in  std_logic;
+        mixout      : out std_logic_vector(13 downto 0 )
+    );
+end oplldelay;
+
+architecture RTL of oplldelay is
+	
+	signal counter: integer range 0 to 72*6;
+
+	signal AdressBuf : std_logic;
+	signal DboBuf	 : std_logic_vector(7 downto 0);
+	signal WE_NBuf   : std_logic;
+
+
+begin
+	process(xin)
+	begin
+		if rising_edge(xin) then
+			if counter/=0 then
+				counter <= counter-1;
+			else
+				if we_n='0' then
+					if delay='1' then
+						if a='0' then
+							counter <= 4*6;
+						else
+							counter <= 72*6;
+						end if;
+					end if;
+					AdressBuf <= a;
+					dbobuf <= d;
+					WE_NBuf <= we_n;
+				end if;
+			end if;
+
+		end if;
+	end process;
+	fm:work.opll
+	port map
+	(
+		xin		=> xin,
+		xena		=> xena,
+		d        => dbobuf,
+		a        => AdressBuf,
+		cs_n     => '0',
+		we_n		=> WE_NBuf,
+		ic_n		=> ic_n,
+		mixout   => mixout
+	);
+end RTL;

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -16,6 +16,7 @@ entity system is
 		ce_vdp:		in	 STD_LOGIC;
 		ce_pix:		in	 STD_LOGIC; 
 		ce_sp:		in	 STD_LOGIC;
+		turbo:		in	 STD_LOGIC;
 		gg:			in	 STD_LOGIC;
 		ggres:			in STD_LOGIC;
 		systeme:		in  STD_LOGIC;
@@ -207,7 +208,7 @@ architecture Behavioral of system is
 	signal nvram_e:         std_logic := '0';
 	signal nvram_ex:        std_logic := '0';
 	signal nvram_p:         std_logic := '0';
-	signal nvram_cme:       std_logic := '0'; -- cpdemasters ram extension
+	signal nvram_cme:       std_logic := '0'; -- codemasters ram extension
 	signal nvram_D_out:     std_logic_vector(7 downto 0);
 	
 	signal lock_mapper_B:	std_logic := '0';
@@ -417,11 +418,12 @@ begin
 		rst		=> not RESET_n
 	);
 	
-	fm: work.opll
+	fm: work.oplldelay
    port map
 	(
 		xin		=> clk_sys,
-		xena		=> ce_cpu,
+		xena		=> ce_cpu, 
+		delay => turbo,
 		d        => D_in,
 		a        => A(0),
 		cs_n     => '0',
@@ -523,7 +525,7 @@ port map(
 		RESET_n	=> RESET_n
 	);
 	
-	ce_z80 <= ce_pix when systeme = '1' else ce_cpu;
+	ce_z80 <= ce_pix when (systeme = '1' or turbo='1') else ce_cpu;
 
 	ram_a <= A(13 downto 0) when systeme = '1' else '0' & A(12 downto 0);
 	ram_we <= ram_WR;


### PR DESCRIPTION
This helps eliminate Slowdown in games like Aleste, Sonic Chaos. The FM chip needs a buffer in this case, so one was added.
The delay might need some tweaking, I took the values as is from OCM.