### PR TITLE
Update edge detection method from VHDL 87 to VHDL 93

### DIFF
--- a/rtl/VM2413/attacktable.vhd
+++ b/rtl/VM2413/attacktable.vhd
@@ -117,7 +117,7 @@ begin
 
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             if( clkena = '1' )then
                 ff_d1 <= ar_adjust( conv_integer( w_addr1 ) );
                 ff_d2 <= ar_adjust( conv_integer( w_addr2 ) );
@@ -127,7 +127,7 @@ begin
 
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             if( clkena = '1' )then
                 ff_w <= addr( 14 downto 7 );    --  データ自体のビット数が 7bit なので 8bit で十分
             end if;
@@ -149,7 +149,7 @@ begin
 
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             if( clkena = '1' )then
                 data <=w_inter( 12 downto 0 );  --  MSB は必ず 0
             end if;

--- a/rtl/VM2413/controller.vhd
+++ b/rtl/VM2413/controller.vhd
@@ -181,7 +181,7 @@ begin   -- rtl
     begin
         if( reset = '1' )then
             regs_addr   <= (others => '0');
-        elsif( clk'event and clk = '1' )then
+        elsif rising_edge(clk) then
             if clkena='1' then
                 if( stage = "00" )then
                     regs_addr <= slot( 4 downto 1 );
@@ -197,7 +197,7 @@ begin   -- rtl
     begin
         if( reset = '1' )then
             slot_voice_addr <= 0;
-        elsif( clk'event and clk = '1' )then
+        elsif rising_edge(clk) then
             if clkena='1' then
                 if( stage = "00" )then
                     if( rflag(5) = '1' and w_channel >= "0110" )then
@@ -260,7 +260,7 @@ begin   -- rtl
             extra_mode := '0';
             vindex := 0;
 
-        elsif clk'event and clk='1' then if clkena='1' then
+        elsif rising_edge(clk) then if clkena='1' then
 
             case stage is
             --------------------------------------------------------------------------

--- a/rtl/VM2413/envelopegenerator.vhd
+++ b/rtl/VM2413/envelopegenerator.vhd
@@ -120,7 +120,7 @@ begin
     begin
         if( reset = '1' )then
             rslot   <= (others => '0');
-        elsif( clk'event and clk='1' )then
+        elsif rising_edge(clk) then
             if( clkena = '1' )then
                 if( stage = "10" )then
                     if( slot = "10001" )then
@@ -153,7 +153,7 @@ begin
             amphase(amphase'high downto amphase'high-4) := "00001";
             amphase(amphase'high-5 downto 0)            := (others=>'0');
 
-        elsif( clk'event and clk='1' )then
+        elsif rising_edge(clk) then
 
             aridx <= egphase( 22-1 downto 0 );
 

--- a/rtl/VM2413/envelopememory.vhd
+++ b/rtl/VM2413/envelopememory.vhd
@@ -62,7 +62,7 @@ begin
 
      init_slot := 0;
 
-   elsif clk'event and clk = '1' then
+   elsif rising_edge(clk) then
 
      if init_slot /= 18 then
        egdata_set(init_slot) <= (others=>'1');

--- a/rtl/VM2413/feedbackmemory.vhd
+++ b/rtl/VM2413/feedbackmemory.vhd
@@ -68,7 +68,7 @@ begin
 
       init_ch := 0;
 
-    elsif clk'event and clk='1' then
+    elsif rising_edge(clk) then
 
       if init_ch /= 9 then
 

--- a/rtl/VM2413/lineartable.vhd
+++ b/rtl/VM2413/lineartable.vhd
@@ -131,7 +131,7 @@ begin
 
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             --  アドレス指定された次のサイクルで対応する値が出てくる（1cycle delay）
             ff_data0 <= log2lin_data( conv_integer( addr(12 downto 6) ) );
             ff_data1 <= log2lin_data( conv_integer( w_addr1           ) );
@@ -140,7 +140,7 @@ begin
 
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             ff_sign     <= addr( 13 );
             ff_weight   <= addr( 5 downto 0 );
         end if;
@@ -161,7 +161,7 @@ begin
 
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             data <= (
                 sign    => ff_sign,
                 value   => w_inter( 8 downto 0 )

--- a/rtl/VM2413/operator.vhd
+++ b/rtl/VM2413/operator.vhd
@@ -113,7 +113,7 @@ begin
         if( reset = '1' )then
             opout       <= (others => '0');
             ff_egout    <= (others => '0');
-        elsif( clk'event and clk='1' )then
+        elsif rising_edge(clk) then
             if( clkena = '1' )then
                 if( stage = "00" )then
                     --  サイン波の参照アドレス（位相）を決定するステージ

--- a/rtl/VM2413/opll.vhd
+++ b/rtl/VM2413/opll.vhd
@@ -259,7 +259,7 @@ begin
         if( reset ='1' )then
             opllwr  <= '0';
             opllptr <= (others =>'0');
-        elsif( xin'event and xin = '1' )then
+        elsif rising_edge(xin) then
             if( xena = '1' )then
                 if(    cs_n = '0' and we_n = '0' and a = '0' )then
                     opllptr <= d;

--- a/rtl/VM2413/outputgenerator.vhd
+++ b/rtl/VM2413/outputgenerator.vhd
@@ -155,7 +155,7 @@ begin
         if( reset = '1' )then
             mo_wr <= '0';
             fb_wr <= '0';
-        elsif( clk'event and clk = '1' )then
+        elsif rising_edge(clk) then
             if( clkena = '1' )then
                 mo_addr <= slot;
 

--- a/rtl/VM2413/outputmemory.vhd
+++ b/rtl/VM2413/outputmemory.vhd
@@ -64,7 +64,7 @@ begin
 
       init_ch := 0;
 
-    elsif clk'event and clk='1' then
+    elsif rising_edge(clk) then
 
       if init_ch /= 18 then
 

--- a/rtl/VM2413/phasegenerator.vhd
+++ b/rtl/VM2413/phasegenerator.vhd
@@ -110,7 +110,7 @@ begin
       noise14 := '0';
       noise17 := '0';
 
-    elsif clk'event and clk='1' then if clkena = '1' then
+    elsif rising_edge(clk) then if clkena = '1' then
 
       noise <= noise14 xor noise17;
 

--- a/rtl/VM2413/phasememory.vhd
+++ b/rtl/VM2413/phasememory.vhd
@@ -63,7 +63,7 @@ begin
 
       init_slot := 0;
 
-   elsif clk'event and clk = '1' then
+   elsif rising_edge(clk) then
 
      if init_slot /= 18 then
 

--- a/rtl/VM2413/registermemory.vhd
+++ b/rtl/VM2413/registermemory.vhd
@@ -61,7 +61,7 @@ begin
     begin
         if( reset = '1' )then
             init_state := 0;
-        elsif( clk'event and clk ='1' )then
+        elsif rising_edge(clk) then
             if( init_state /= 9 )then
                 --  ‹N“®‚µ‚Ä‚·‚®‚É RAM ‚Ì“à—e‚ğ‰Šú‰»‚·‚é
                 regs_array( init_state ) <= (others => '0');

--- a/rtl/VM2413/sinetable.vhd
+++ b/rtl/VM2413/sinetable.vhd
@@ -141,7 +141,7 @@ begin
     --  ”gŒ`ƒƒ‚ƒŠ
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             if( clkena = '1' )then
                 ff_data0 <= sin_data( conv_integer( w_addr0 ) );
                 ff_data1 <= sin_data( conv_integer( w_addr1 ) );
@@ -152,7 +152,7 @@ begin
     --  Cüî•ñ‚Ì’x‰„i”gŒ`ƒƒ‚ƒŠ‚Ì“Ç‚İo‚µ’x‰„‚É‚ ‚í‚¹‚éj
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             if( clkena = '1' )then
                 ff_sign     <= addr(17);
                 ff_wf       <= wf and addr(17);
@@ -178,7 +178,7 @@ begin
 
     process( clk )
     begin
-        if( clk'event and clk = '1' )then
+        if rising_edge(clk) then
             if( clkena = '1' )then
                 --  •âŠÔ‰‰Z‚ÌŒ‹‰Ê‚ğ‚¢‚Á‚½‚ñ FF ‚É“ü‚ê‚Ä‰‰Z’x‰„‚ğ‹zû
                 ff_data <= (ff_sign & w_inter(12 downto 0)) or w_wf;

--- a/rtl/VM2413/slotcounter.vhd
+++ b/rtl/VM2413/slotcounter.vhd
@@ -59,7 +59,7 @@ begin
     begin
         if( reset = '1' )then
             ff_count <= "1000111" - delay;
-        elsif( clk'event and clk='1' )then
+        elsif rising_edge(clk) then
             if( clkena ='1' )then
                 if( ff_count = "1000111" )then      -- 71
                     ff_count <= (others => '0');

--- a/rtl/VM2413/temporalmixer.vhd
+++ b/rtl/VM2413/temporalmixer.vhd
@@ -69,7 +69,7 @@ begin
 		mix    <= (others =>'0');
 		mixout <= (others =>'0');
 
-    elsif clk'event and clk = '1' then if clkena='1' then
+    elsif rising_edge(clk) then if clkena='1' then
 
       if stage = 0 then
 

--- a/rtl/VM2413/voicememory.vhd
+++ b/rtl/VM2413/voicememory.vhd
@@ -80,7 +80,7 @@ begin
       init_id := 0;
       rstate <= 0;
 
-    elsif clk'event and clk = '1' then
+    elsif rising_edge(clk) then
 
       if init_id /= VOICE_ID_TYPE'high+1 then
 

--- a/rtl/VM2413/voicerom.vhd
+++ b/rtl/VM2413/voicerom.vhd
@@ -184,7 +184,7 @@ begin
 
   begin
 
-    if clk'event and clk = '1' then
+    if rising_edge(clk) then
       if (VRC7 = '0') then
         data <= CONV_VOICE(base_voices(addr));
       else


### PR DESCRIPTION
Changes the edge detection method from VHDL 1987's standard to VHDL 1993's standard in order to secure the core from potential undefined behavior.