### PR TITLE
Revert blanking changes to fix pal + border

### DIFF
--- a/rtl/video.vhd
+++ b/rtl/video.vhd
@@ -12,8 +12,8 @@ entity video is
 		ggres:        in  std_logic :='0';
 		mask_column:	in  std_logic := '0';
 		cut_mask:		in	std_logic;
-		smode_M1:		in	 std_logic;
-		smode_M3:		in	 std_logic;
+		smode_M1:		in	 std_logic; -- 224p mode
+		smode_M3:		in	 std_logic; -- 240p mode
 		
 		x: 				out std_logic_vector(8 downto 0);
 		y:					out std_logic_vector(8 downto 0);
@@ -115,18 +115,17 @@ begin
 	x	<= hcount;
 	y	<= vcount;
 
-	vbl_st  <= conv_std_logic_vector(184,9) when (smode_M1='1' and ggres='1')
+	vbl_st  <= conv_std_logic_vector(184,9) when (smode_M1='1' and ggres='1' and border='0')
 			else conv_std_logic_vector(224,9) when smode_M1 = '1'
 			else conv_std_logic_vector(240,9) when smode_M3 = '1'
-			else conv_std_logic_vector(216,9) when border = '1' and pal = '0'
-			else conv_std_logic_vector(240,9) when border = '1'
-			else conv_std_logic_vector(192,9) when ggres = '0'
+			else conv_std_logic_vector(216,9) when border = '1' and ggres = '0'
+			else conv_std_logic_vector(192,9) when (border xor ggres) = '0'
 			else conv_std_logic_vector(168,9);
-			
-	vbl_end <= conv_std_logic_vector(40,9)  when (smode_M1='1' and ggres='1')
-			else conv_std_logic_vector(000,9) when smode_M1 = '1' or smode_M3 = '1' or (border = '0' and ggres = '0')
-			else conv_std_logic_vector(488,9) when border = '1' and pal = '0'
-			else conv_std_logic_vector(458,9) when border = '1'
+
+	vbl_end <= conv_std_logic_vector(40,9)  when (smode_M1='1' and ggres='1' and border='0')
+			else conv_std_logic_vector(000,9) when smode_M1 = '1' or smode_M3 = '1' 
+			else conv_std_logic_vector(488,9) when border = '1' and ggres = '0'
+			else conv_std_logic_vector(000,9) when (border xor ggres) = '0'
 			else conv_std_logic_vector(024,9);
 
 	hbl_st  <= conv_std_logic_vector(270,9) when border = '1' and ggres = '0'


### PR DESCRIPTION
The blanking changes in this commit --> https://github.com/MiSTer-devel/SMS_MiSTer/commit/cbef92c6e7c7afb2997d807a584f38db2ae46c8a - negatively impacted PAL + border going to the scaler. They must have been done incorrectly. This was also leading to direct video output over PAL with border on looking incorrect.

Fixes --> https://github.com/MiSTer-devel/SMS_MiSTer/issues/120

If the blanking needs to be fixed further, care must be taken to test scaled and analog output next time.