### PR TITLE
MiST target builds again.

### DIFF
--- a/mist/SMS.sv
+++ b/mist/SMS.sv
@@ -362,7 +362,7 @@ video video
 	.clk(clk_sys),
 	.ce_pix(ce_pix),
 	.pal(palmode),
-	.gg(gg),
+	.ggres(gg),
 	.border(~gg),
 	.mask_column(mask_column),
 	.x(x),

--- a/mist/sms_mist.qsf
+++ b/mist/sms_mist.qsf
@@ -318,4 +318,8 @@ set_global_assignment -name SIGNALTAP_FILE output_files/stp1.stp
 set_global_assignment -name VERILOG_FILE ../rtl/hybrid_pwm_sd.v
 set_global_assignment -name VHDL_FILE ../rtl/AudioMix.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE ../rtl/lightgun.sv
+
+set_global_assignment -name VERILOG_FILE ../rtl/MC8123.v
+set_global_assignment -name VERILOG_FILE ../rtl/SEGASYS1_PRGDEC.v
+set_global_assignment -name VERILOG_FILE ../rtl/parts.v
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top


### PR DESCRIPTION
I've updated the MiST target so that it's buildable once again (adding some new components which weren't part of the project file, and changing a couple of signal names for the Video module).  I've confirmed that it runs and can load a few games (sms, gg and sg) but I don't know the platform well enough to know whether anything's broken, so it needs more rigorous testing.