### PR TITLE
Switch to SG-1000's correct palette for .SG ROMs

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -564,7 +564,7 @@ always_ff @(posedge clk_sys) begin
 	if (code_download & ioctl_wr) begin
 		case (ioctl_addr[3:0])
 			0:  gg_code[111:96]  <= ioctl_dout; // Flags Bottom Word
-			1:  gg_code[119:112]  <= ioctl_dout; // Flags Bottom Word
+			1:  gg_code[119:112] <= ioctl_dout; // Flags Bottom Word
 			2:  gg_code[127:120] <= ioctl_dout; // Flags Top Word
 			3:  gg_code[127:112] <= ioctl_dout; // Flags Top Word
 			4:  gg_code[71:64]   <= ioctl_dout; // Address Bottom Word
@@ -575,7 +575,7 @@ always_ff @(posedge clk_sys) begin
 			9:  gg_code[47:40]   <= ioctl_dout; // Compare Bottom Word
 			10: gg_code[55:48]   <= ioctl_dout; // Compare top Word
 			11: gg_code[63:56]   <= ioctl_dout; // Compare top Word
-			12: gg_code[7:0]    <= ioctl_dout; // Replace Bottom Word
+			12: gg_code[7:0]     <= ioctl_dout; // Replace Bottom Word
 			13: gg_code[15:8]    <= ioctl_dout; // Replace Bottom Word
 			14: gg_code[23:16]   <= ioctl_dout; // Replace Top Word
 			15: begin
@@ -592,29 +592,34 @@ always @(posedge clk_sys) begin
 	if(cart_download || bk_loading) dbr <= 1;
 end
 
-reg gg = 0;
-reg systeme = 0;
+reg        gg          = 0;
+reg        systeme     = 0;
+reg        palettemode = 0;
 reg [21:0] cart_mask, cart_mask512;
-reg cart_sz512;
+reg        cart_sz512;
 
 always @(posedge clk_sys) begin
 	reg old_download;
 	old_download <= cart_download;
 
-	if(ioctl_wr & cart_download) begin
+	if (ioctl_wr & cart_download) begin
 		cart_mask <= cart_mask | ioctl_addr[21:0];
 		cart_mask512 <= cart_mask512 | (ioctl_addr[21:0] - 10'd512);
-		if(!ioctl_addr) cart_mask <= 0;
-		if(ioctl_addr == 512) cart_mask512 <= 0;
-		gg <= ioctl_index[4:0] == 2;	
+		if (!ioctl_addr) 
+			cart_mask <= 0;
+		if (ioctl_addr == 512) 
+			cart_mask512 <= 0;
+			gg <= ioctl_index[4:0] == 2;	
 		if ((ioctl_index[4:0] == 1) || (ioctl_index[4:0] == 2))
-		systeme <= 1'b0;
+			systeme <= 1'b0;
+		if ((ioctl_index[4:0] == 1) && (ioctl_index[6:5] == 2'b10)) // .SG file extension
+			palettemode <= 1'b1;
 	end;
 	if (old_download & ~cart_download) begin
 		cart_sz512 <= ioctl_addr[9];
 	end;
 	if (ioctl_wr & (ioctl_index==4)) begin
-		systeme <= 1'b1;;
+		systeme <= 1'b1;
 	end;
 end
 
@@ -696,6 +701,7 @@ system #(63) system
 	.x(x),
 	.y(y),
 	.color(color),
+	.palettemode(palettemode),
 	.mask_column(mask_column),
 	.black_column(status[28] && ~status[13]),
 	.smode_M1(smode_M1),

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -77,6 +77,7 @@ entity system is
 		x:				in	 STD_LOGIC_VECTOR(8 downto 0);
 		y:				in	 STD_LOGIC_VECTOR(8 downto 0);
 		color:		out STD_LOGIC_VECTOR(11 downto 0);
+		palettemode:	in	STD_LOGIC;
 		mask_column:out STD_LOGIC;
 		black_column:		in STD_LOGIC;
 		smode_M1:		out STD_LOGIC;
@@ -346,6 +347,7 @@ begin
 		x			=> x,
 		y			=> y,
 		color		=> vdp_color,
+		palettemode	=> palettemode,
 		y1       => vdp_y1,
 		smode_M1  => smode_M1,
 		smode_M2  => smode_M2,
@@ -383,6 +385,7 @@ begin
 		x			=> x,
 		y			=> y,
 		color		=> vdp2_color,
+		palettemode	=> palettemode,
 		y1       => vdp2_y1,
 --		smode_M1  => smode2_M1,
 --		smode_M2  => smode2_M2,

--- a/rtl/vdp.vhd
+++ b/rtl/vdp.vhd
@@ -28,6 +28,7 @@ entity vdp is
 		x:					in  STD_LOGIC_VECTOR (8 downto 0);
 		y:					in  STD_LOGIC_VECTOR (8 downto 0);
 		color:			out STD_LOGIC_VECTOR (11 downto 0);
+		palettemode:	in STD_LOGIC;
 		y1:            out std_logic;
 		mask_column:   out STD_LOGIC;
 		black_column:		in STD_LOGIC;
@@ -141,6 +142,7 @@ begin
 		y					=> y,
 
 		color				=> color,
+		palettemode			=> palettemode,
 		y1					=> y1,
 		smode_M1			=> xmode_M1,
 		smode_M3			=> xmode_M3,

--- a/rtl/vdp_main.vhd
+++ b/rtl/vdp_main.vhd
@@ -23,6 +23,7 @@ entity vdp_main is
 		y:						in  std_logic_vector(8 downto 0);
 			
 		color:				out std_logic_vector (11 downto 0);
+		palettemode:		in std_logic;
 		y1:               out std_logic;
 					
 		display_on:			in  std_logic;
@@ -178,20 +179,34 @@ begin
 	vram_A <= spr_vram_A when x>=256 and x<496 else bg_vram_A;  -- Does bg only need x<504 only?
 	color <= "000000000000" when black_column='1' and mask_column0='1' and x>0 and x<9 else
 			cram_D when smode_M4='1' else 
-			"000000000000" when out_color="0000" else 
-			"000000000000" when out_color="0001" else 
-			"010010100010" when out_color="0010" else 
-			"011111100110" when out_color="0011" else 
-			"111101010101" when out_color="0100" else 
-			"111110001000" when out_color="0101" else 
-			"010101011101" when out_color="0110" else 
-			"111111110100" when out_color="0111" else 
-			"010101011111" when out_color="1000" else 
-			"100010001111" when out_color="1001" else 
-			"010111011101" when out_color="1010" else 
-			"100011011110" when out_color="1011" else 
-			"010010110010" when out_color="1100" else 
-			"101001101011" when out_color="1101" else 
-			"101110111011" when out_color="1110" else 
-			"111111111111";
+			-- How an SMS VDP handles Legacy TMS Modes to produce these values
+			x"000" when   out_color="0000" or out_color="0001" else -- Transparent or Black
+			X"4A2" when (out_color="0010" and palettemode='0') else -- Medium Green
+			X"7E6" when (out_color="0011" and palettemode='0') else -- Light Green
+			X"F55" when (out_color="0100" and palettemode='0') else -- Dark Blue
+			X"F88" when (out_color="0101" and palettemode='0') else -- Light Blue
+			X"55D" when (out_color="0110" and palettemode='0') else -- Dark red
+			X"FF4" when (out_color="0111" and palettemode='0') else -- Cyan
+			X"55F" when (out_color="1000" and palettemode='0') else -- Medium Red
+			X"88F" when (out_color="1001" and palettemode='0') else -- Light Red
+			X"5DD" when (out_color="1010" and palettemode='0') else -- Dark Yellow
+			X"8DE" when (out_color="1011" and palettemode='0') else -- Light Yellow
+			X"4B2" when (out_color="1100" and palettemode='0') else -- Dark Green
+			X"A6B" when (out_color="1101" and palettemode='0') else -- Magenta
+			X"BBB" when (out_color="1110" and palettemode='0') else -- Gray
+			-- Equivalent values to original TMS chip output from SG-1000
+			x"4C2" when (out_color="0010" and palettemode='1') else -- Medium Green
+			x"7D5" when (out_color="0011" and palettemode='1') else -- Light Green
+			x"E55" when (out_color="0100" and palettemode='1') else -- Dark Blue
+			x"F77" when (out_color="0101" and palettemode='1') else -- Light Blue
+			x"45D" when (out_color="0110" and palettemode='1') else -- Dark red
+			x"FE4" when (out_color="0111" and palettemode='1') else -- Cyan
+			x"55F" when (out_color="1000" and palettemode='1') else -- Medium Red
+			x"77F" when (out_color="1001" and palettemode='1') else -- Light Red
+			x"5CD" when (out_color="1010" and palettemode='1') else -- Dark Yellow
+			x"8CE" when (out_color="1011" and palettemode='1') else -- Light Yellow
+			x"3B2" when (out_color="1100" and palettemode='1') else -- Dark Green
+			x"B5C" when (out_color="1101" and palettemode='1') else -- Magenta
+			x"CCC" when (out_color="1110" and palettemode='1') else -- Gray
+			x"FFF";                                                 -- White
 end Behavioral;


### PR DESCRIPTION
The SG-1000 TMS9918A had a different palette than the SMS/Mark III palette (https://www.smspower.org/Development/Palette#SG1000SC3000) This change approximates the TMS9918A values from the documentation found here --> http://bifi.msxnet.org/msxnet/tech/tms9918a.txt

~~A toggle was added to the OSD, default setting is the current behavior of the core, toggle enabled switches to the sg-1000 palette during video modes that aren't smode_M4.~~ EDIT: Changed to auto-switching solely on .SG ROM load, on account of advice from @Kitrinx.

Also switched to hex values for color table based on advice from @wickerwaka (makes it simpler to read), and I simplified transparent/black to one or operation.

Comparison screenshots:

**SMS VDP's palette for TMS modes**
![SMS](https://user-images.githubusercontent.com/16388068/184073528-c9473a77-49a2-4ced-83ea-dfa32fb3bf0a.png)

**SG-1000 VDP's palette for TMS modes**
![SG-1000](https://user-images.githubusercontent.com/16388068/184073570-8382e6ab-c845-42a9-bd5d-8cc5c83b113c.png)

Note the switched colors on the two trees next to each other. Another great example to hopefully justify this option:

**SMS VDP's palette for TMS modes**
![SMS ingame](https://user-images.githubusercontent.com/16388068/184073714-27c6e875-abfe-4539-87e8-abd792fc47a0.png)

**SG-1000 VDP's palette for TMS modes**
![SG-1000 ingame](https://user-images.githubusercontent.com/16388068/184073706-7a3689ab-abfa-44be-95ab-e8467de0ee06.png)