### PR TITLE
Implement savestates and enhance detection for Zemina/Nemesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This core is a port of Ben's Sega Master System implementation for the Papilio. 
 * Z80 Turbo Option
 * Lightgun, Paddle controls, Keyboard(SK-1100) and Multitap Support
 * Gear to Gear link cable over USERIO
+* BIOS Loading Support
+* Savestates
 
 ## Where to Download
 
@@ -33,6 +35,7 @@ This core is a port of Ben's Sega Master System implementation for the Papilio. 
 * The "Region" parameter toggle some hardware features that are specific to the different console models. Some localized games need these modifications to work properly. If a game doesn't work right, try to toggle this setting and reset the game in order to troubleshoot.
 * Each game cartridge comes with a specific mapper, which description is not included in the .gg ou .sms file. The core has a special logic to automatically determine which mapper needs to be used, but some games make a good effort to make this logic fail. The "Mapper" parameter permits to force the usage of specific mappers in case the automatic detection fails.
 * The "Masked left column" option controls behaviour of left column when hidden by system (usually during horizontal scrolling). "BG" sets it to the background/overscan colour, as on original hardware. "Black" makes it black, which may look better on non full-screen settings as the column will blend in with surrounding black area. "Cut" will remove the column from the active image, so the horizontal resolution becomes 248 instead of 256. This will distort the image when scaled, particularly on integer scaling settings, but will use more of the screen. When "Border" is set to "Yes" the left column is always shown as part of the border, so "Masked left column" is disabled.
+* Regular ROMs savestates are persistent in the SD card. BIOS built-in games will save to memory only (non-persistent). Workaround: load the BIOS and an empty ROM.
 
 ### Gear To Gear USERIO Mapping
 

--- a/SMS.sv
+++ b/SMS.sv
@@ -190,7 +190,8 @@ assign LED_POWER = 0;
 assign BUTTONS   = osd_btn;
 assign VGA_SCALER= 0;
 assign VGA_DISABLE = 0;
-assign HDMI_FREEZE = 0;
+wire ss_freeze;
+assign HDMI_FREEZE = ss_freeze;
 assign HDMI_BLACKOUT = 0;
 assign HDMI_BOB_DEINT = 0;
 assign FB_FORCE_BLANK = 0;
@@ -208,7 +209,7 @@ end
 wire video_rotated;
 wire no_rotate = ~status[41];
 wire flip = status[42];
-wire rotate_ccw = 0;
+wire rotate_ccw = 1'b0;
 wire [5:0] arx, ary;
 
 always_comb begin
@@ -238,7 +239,36 @@ end
 
 wire [1:0] ar = status[27:26];
 wire vga_de;
-screen_rotate screen_rotate (.*);
+screen_rotate screen_rotate (
+	.CLK_VIDEO     (CLK_VIDEO),
+	.CE_PIXEL      (CE_PIXEL),
+	.VGA_R         (VGA_R),
+	.VGA_G         (VGA_G),
+	.VGA_B         (VGA_B),
+	.VGA_HS        (VGA_HS),
+	.VGA_VS        (VGA_VS),
+	.VGA_DE        (VGA_DE),
+	.rotate_ccw    (rotate_ccw),
+	.no_rotate     (no_rotate),
+	.flip          (flip),
+	.video_rotated (video_rotated),
+	.FB_EN         (FB_EN),
+	.FB_FORMAT     (FB_FORMAT),
+	.FB_WIDTH      (FB_WIDTH),
+	.FB_HEIGHT     (FB_HEIGHT),
+	.FB_BASE       (FB_BASE),
+	.FB_STRIDE     (FB_STRIDE),
+	.FB_VBL        (FB_VBL),
+	.FB_LL         (FB_LL),
+	.DDRAM_CLK     (sr_ddram_clk),
+	.DDRAM_BUSY    (DDRAM_BUSY),
+	.DDRAM_BURSTCNT(sr_ddram_burstcnt),
+	.DDRAM_ADDR    (sr_ddram_addr),
+	.DDRAM_DIN     (sr_ddram_din),
+	.DDRAM_BE      (sr_ddram_be),
+	.DDRAM_WE      (sr_ddram_we),
+	.DDRAM_RD      (sr_ddram_rd)
+);
 video_freak video_freak
 (
 	.*,
@@ -260,10 +290,14 @@ video_freak video_freak
 
 `include "build_id.v"
 parameter CONF_STR = {
-	"SMS;;",
+	"SMS;SS3E000000:10000;",
 	"-;",
 	"H8FS1,SMSSG SC ;",
 	"H8FS2,GG;",
+	"-;",
+	"H8O[16:15],SaveState Slot,1,2,3,4;",
+	"H8R[61],Save State (Alt+F1);",
+	"H8R[62],Load State (F1);",
 	"DIP;",
 	"-;",
 	"C,Cheats;",
@@ -276,7 +310,7 @@ parameter CONF_STR = {
 
 	"H8OA,Region,US/EU,Japan;",
 	"H8oBC,BIOS,Disable,Internal,Ext. File;",
-	"H8FS3,BINSMS,Load Ext. BIOS;",
+	"H8F3,BINSMS,Load Ext. BIOS;",
 	"H8O[48:45],Mapper,Auto,Sega,Codemasters,Dahjee A,Linear,Zemina/MSX;",
 	"H8o8,Z80 Speed,Normal,Turbo;",
 	"H8-;",
@@ -484,6 +518,7 @@ wire  [8:0] sd_buff_addr;
 wire  [7:0] sd_buff_dout;
 wire  [7:0] sd_buff_din;
 wire        sd_buff_wr;
+
 wire        img_mounted;
 wire        img_readonly;
 wire [63:0] img_size;
@@ -842,6 +877,51 @@ wire        ram_we;
 wire  [7:0] ram_d;
 wire  [7:0] ram_q;
 
+// Save-state wires
+wire [7:0]  ss_ddram_burstcnt;
+wire [28:0] ss_ddram_addr;
+wire [63:0] ss_ddram_din;
+wire [7:0]  ss_ddram_be;
+wire        ss_ddram_we;
+wire        ss_ddram_rd;
+wire [211:0] ss_z80_reg, ss_z80_dir;
+wire         ss_z80_set;
+wire         ss_z80_m1_n;
+wire         ss_z80_mreq_n;   // low = normal opcode fetch, high = interrupt ack
+wire   [1:0] ss_z80_iset;     // "00" = clean instruction boundary (no prefix)
+wire [127:0] ss_vdp_regs, ss_vdp_regs_in;
+wire         ss_vdp_regs_set;
+wire [383:0] ss_vdp_cram;
+wire  [4:0]  ss_cram_A;
+wire [11:0]  ss_cram_D;
+wire         ss_cram_wr;
+wire         ss_vram_en;
+wire [14:0]  ss_vram_A, ss_vram_WA;
+wire  [7:0]  ss_vram_D, ss_vram_WD;
+wire         ss_vram_WE;
+wire [55:0]  ss_psg_out, ss_psg_in;
+wire         ss_psg_set;
+wire [63:0]  ss_mapper_out, ss_mapper_in;
+wire         ss_mapper_set;
+wire [13:0]  ss_wram_A, ss_wram_WA;
+wire  [7:0]  ss_wram_WD;
+wire         ss_wram_WE;
+wire [1:0]   ss_slot;
+wire         ss_save_raw, ss_load_raw;
+wire         ss_save, ss_load;
+wire         ss_bios_mode = bios_en & ~dbr;
+wire         ss_state_allowed = dbr | ss_bios_mode;
+assign ss_save = ss_save_raw & ss_state_allowed;
+assign ss_load = ss_load_raw & ss_state_allowed;
+
+wire        sr_ddram_clk;
+wire [7:0]  sr_ddram_burstcnt;
+wire [28:0] sr_ddram_addr;
+wire [63:0] sr_ddram_din;
+wire [7:0]  sr_ddram_be;
+wire        sr_ddram_we;
+wire        sr_ddram_rd;
+
 wire [3:0] mapper_sel = status[48:45];
 wire mapper_force_sega      = (mapper_sel == 4'd1) & ~systeme;
 wire mapper_force_codies    = (mapper_sel == 4'd2);
@@ -854,13 +934,20 @@ wire        nvram_we;
 wire  [7:0] nvram_d;
 wire  [7:0] nvram_q;
 
+// NVRAM DMA wires (savestates → nvram_inst during ss_freeze)
+wire [12:0] ss_nvram_A;    // DMA read address
+wire        ss_nvram_WE;   // DMA write enable
+wire [12:0] ss_nvram_WA;   // DMA write address
+wire  [7:0] ss_nvram_WD;   // DMA write data
+// nvram_q feeds ss_nvram_D directly (read data back to savestates)
+
 system #(63) system
 (
 	.clk_sys(clk_sys),
-	.ce_cpu(ce_cpu),
-	.ce_vdp(ce_vdp),
-	.ce_pix(ce_pix),
-	.ce_sp(ce_sp),
+	.ce_cpu(ce_cpu & ~ss_freeze),
+	.ce_vdp(ce_vdp & ~ss_freeze),
+	.ce_pix(ce_pix & ~ss_freeze),
+	.ce_sp(ce_sp  & ~ss_freeze),
 	.turbo(turbo),
 	.gg(gg),
 	.ggres(ggres),
@@ -977,8 +1064,118 @@ system #(63) system
 	.ROMAD(ioctl_addr),
 	.ROMDT(ioctl_dout),
 	.ROMEN(ioctl_wr & ((ioctl_index[4:0]==1) || (ioctl_index[4:0]==2))),
-	.BIOSWEN(ioctl_wr & (ioctl_index[4:0]==3))
+	.BIOSWEN(ioctl_wr & (ioctl_index[4:0]==3)),
+
+	// Save-state interface
+	.z80_reg_out (ss_z80_reg),
+	.z80_dir     (ss_z80_dir),
+	.z80_set     (ss_z80_set),
+	.vdp_regs_out(ss_vdp_regs),
+	.vdp_regs_in (ss_vdp_regs_in),
+	.vdp_regs_set(ss_vdp_regs_set),
+	.vdp_cram_out(ss_vdp_cram),
+	.ss_cram_wr  (ss_cram_wr),
+	.ss_cram_A   (ss_cram_A),
+	.ss_cram_D   (ss_cram_D),
+	.ss_vram_en  (ss_vram_en),
+	.ss_vram_A   (ss_vram_A),
+	.ss_vram_D   (ss_vram_D),
+	.ss_vram_WE  (ss_vram_WE),
+	.ss_vram_WA  (ss_vram_WA),
+	.ss_vram_WD  (ss_vram_WD),
+	.psg_out     (ss_psg_out),
+	.psg_in      (ss_psg_in),
+	.psg_set     (ss_psg_set),
+	.mapper_out  (ss_mapper_out),
+	.mapper_in   (ss_mapper_in),
+	.mapper_set  (ss_mapper_set),
+	.z80_m1_n    (ss_z80_m1_n),
+	.z80_mreq_n  (ss_z80_mreq_n),
+	.z80_iset    (ss_z80_iset)
 );
+
+savestate_ui savestate_ui_inst (
+	.clk    (clk_sys),
+	.status (status),
+	.ps2_key(ps2_key),
+	.ss_slot(ss_slot),
+	.ss_save(ss_save_raw),
+	.ss_load(ss_load_raw)
+);
+
+savestates savestates_inst (
+	.clk             (clk_sys),
+	.reset_n         (~reset_active),
+	.ss_save         (ss_save),
+	.ss_load         (ss_load),
+	.ss_slot         (ss_slot),
+	.ss_bios_mode    (ss_bios_mode),
+	.ss_freeze       (ss_freeze),
+	.vblank          (VBlank),
+	// Z80
+	.z80_reg         (ss_z80_reg),
+	.z80_dir         (ss_z80_dir),
+	.z80_set         (ss_z80_set),
+	.z80_m1_n        (ss_z80_m1_n),
+	.z80_mreq_n      (ss_z80_mreq_n),
+	.z80_iset        (ss_z80_iset),
+	.cpu_ce          (ce_cpu),
+	.vdp_ce          (ce_vdp),
+	// VDP registers
+	.vdp_regs        (ss_vdp_regs),
+	.vdp_regs_in     (ss_vdp_regs_in),
+	.vdp_regs_set    (ss_vdp_regs_set),
+	// CRAM
+	.cram_out        (ss_vdp_cram),
+	.cram_A          (ss_cram_A),
+	.cram_D          (ss_cram_D),
+	.cram_wr         (ss_cram_wr),
+	// VRAM DMA
+	.vram_en         (ss_vram_en),
+	.vram_A          (ss_vram_A),
+	.vram_D          (ss_vram_D),
+	.vram_WE         (ss_vram_WE),
+	.vram_WA         (ss_vram_WA),
+	.vram_WD         (ss_vram_WD),
+	// PSG
+	.psg_out         (ss_psg_out),
+	.psg_in          (ss_psg_in),
+	.psg_set         (ss_psg_set),
+	// Mapper
+	.mapper_out      (ss_mapper_out),
+	.mapper_in       (ss_mapper_in),
+	.mapper_set      (ss_mapper_set),
+	// WRAM DMA
+	.wram_A          (ss_wram_A),
+	.wram_D          (ram_q),
+	.wram_WE         (ss_wram_WE),
+	.wram_WA         (ss_wram_WA),
+	.wram_WD         (ss_wram_WD),
+	// NVRAM DMA (Dahjee A expansion RAM)
+	.nvram_A         (ss_nvram_A),
+	.nvram_D         (nvram_q),
+	.nvram_WE        (ss_nvram_WE),
+	.nvram_WA        (ss_nvram_WA),
+	.nvram_WD        (ss_nvram_WD),
+	// DDRAM
+	.DDRAM_ADDR      (ss_ddram_addr),
+	.DDRAM_DIN       (ss_ddram_din),
+	.DDRAM_BE        (ss_ddram_be),
+	.DDRAM_WE        (ss_ddram_we),
+	.DDRAM_DOUT      (DDRAM_DOUT),
+	.DDRAM_DOUT_READY(DDRAM_DOUT_READY),
+	.DDRAM_RD        (ss_ddram_rd),
+	.DDRAM_BURSTCNT  (ss_ddram_burstcnt),
+	.DDRAM_BUSY      (DDRAM_BUSY)
+);
+
+assign DDRAM_CLK      = clk_sys; // always stable; sr_ddram_clk (CLK_VIDEO) would glitch on ss_freeze toggle
+assign DDRAM_BURSTCNT = ss_freeze ? ss_ddram_burstcnt : sr_ddram_burstcnt;
+assign DDRAM_ADDR     = ss_freeze ? ss_ddram_addr     : sr_ddram_addr;
+assign DDRAM_DIN      = ss_freeze ? ss_ddram_din      : sr_ddram_din;
+assign DDRAM_BE       = ss_freeze ? ss_ddram_be       : sr_ddram_be;
+assign DDRAM_WE       = ss_freeze ? ss_ddram_we       : sr_ddram_we;
+assign DDRAM_RD       = ss_freeze ? ss_ddram_rd       : sr_ddram_rd;
 
 wire [12:0] key_a;
 wire [7:0] key_d;
@@ -1131,9 +1328,10 @@ end
 spram #(.widthad_a(14)) ram_inst
 (
 	.clock     (clk_sys),
-	.address   (ram_clr_run ? ram_clr_addr : (systeme ? ram_a : {1'b0,ram_a[12:0]})),
-	.wren      (ram_clr_run | ram_we),
-	.data      (ram_clr_run ? 8'h00 : ram_d),
+	.address   (ss_freeze ? (ss_wram_WE ? ss_wram_WA : ss_wram_A) :
+	             (ram_clr_run ? ram_clr_addr : (systeme ? ram_a : {1'b0,ram_a[12:0]}))),
+	.wren      (ss_freeze ? ss_wram_WE : (ram_clr_run | ram_we)),
+	.data      (ss_freeze ? ss_wram_WD : (ram_clr_run ? 8'h00 : ram_d)),
 	.q         (ram_q)
 );
 
@@ -1258,12 +1456,12 @@ end
 dpram #(.widthad_a(15)) nvram_inst
 (
 	.clock_a     (clk_sys),
-	.address_a   (nvram_a),
-	.wren_a      (nvram_we),
-	.data_a      (nvram_d),
+	.address_a   (ss_freeze ? (ss_nvram_WE ? {2'b00, ss_nvram_WA} : {2'b00, ss_nvram_A}) : nvram_a),
+	.wren_a      (ss_freeze ? ss_nvram_WE : nvram_we),
+	.data_a      (ss_freeze ? ss_nvram_WD : nvram_d),
 	.q_a         (nvram_q),
 	.clock_b     (clk_sys),
-	.address_b   ({sd_lba[5:0],sd_buff_addr}),
+	.address_b   ({sd_lba[5:0],sd_buff_addr[8:0]}),
 	.wren_b      (sd_buff_wr & sd_ack),
 	.data_b      (sd_buff_dout),
 	.q_b         (sd_buff_din)
@@ -1275,6 +1473,7 @@ reg bk_ena = 0;
 always @(posedge clk_sys) begin
 
 	old_downloading <= downloading;
+	if (eject_rom) bk_ena <= 0;
 	if(~old_downloading & downloading) bk_ena <= 0;
 
 	//Save file always mounted in the end of downloading state.

--- a/SMS.sv
+++ b/SMS.sv
@@ -360,9 +360,23 @@ parameter CONF_STR = {
 	"H8RB,Soft Reset;",
 	"H8R9,Eject ROM;",
 	"R0,Reset;",
-	"J1,Fire 1,Fire 2,Pause,Coin,Arcade 3,Soft Reset;",
+	"J1,Fire 1,Fire 2,Pause,Coin,Arcade 3,Soft Reset,-,-,SaveState;",
 	"jn,A|P,B,Start,Coin,X,Select;",
 	"jp,Y|P,A,Start,Coin,X,Select;",
+	"I,",
+	"Slot=DPAD|Save/Load=Pause+DPAD,",
+	"Active Slot 1,",
+	"Active Slot 2,",
+	"Active Slot 3,",
+	"Active Slot 4,",
+	"Save to state 1,",
+	"Restore state 1,",
+	"Save to state 2,",
+	"Restore state 2,",
+	"Save to state 3,",
+	"Restore state 3,",
+	"Save to state 4,",
+	"Restore state 4;",
 	"V,v",`BUILD_DATE
 };
 
@@ -551,6 +565,9 @@ hps_io #(.CONF_STR(CONF_STR), .WIDE(0)) hps_io
 	.forced_scandoubler(forced_scandoubler),
 	.new_vmode(pal),
 	.gamma_bus(gamma_bus),
+
+	.info_req(ss_info_req),
+	.info(ss_info),
 
 	.ps2_kbd_led_use(0),
 	.ps2_kbd_led_status(0),
@@ -870,6 +887,12 @@ always @(posedge clk_sys) begin
 	if (ioctl_wr & (ioctl_index==4)) begin
 		systeme <= 1'b1;
 	end;
+	// Joystick combo changed the slot — push new value back to OSD
+	if (ss_status) begin
+		status_in        <= {64'd0, status};
+		status_in[16:15] <= ss_slot;
+		status_set       <= 1'b1;
+	end;
 end
 
 wire [13:0] ram_a;
@@ -913,6 +936,10 @@ wire         ss_bios_mode = bios_en & ~dbr;
 wire         ss_state_allowed = dbr | ss_bios_mode;
 assign ss_save = ss_save_raw & ss_state_allowed;
 assign ss_load = ss_load_raw & ss_state_allowed;
+
+wire  [7:0]  ss_info;
+wire         ss_info_req;
+wire         ss_status;    // one-cycle pulse: push new slot to OSD
 
 wire        sr_ddram_clk;
 wire [7:0]  sr_ddram_burstcnt;
@@ -1095,12 +1122,24 @@ system #(63) system
 );
 
 savestate_ui savestate_ui_inst (
-	.clk    (clk_sys),
-	.status (status),
-	.ps2_key(ps2_key),
-	.ss_slot(ss_slot),
-	.ss_save(ss_save_raw),
-	.ss_load(ss_load_raw)
+	.clk         (clk_sys),
+	.status      (status),
+	.ps2_key     (ps2_key),
+	.allow_ss    (ss_state_allowed),
+	.joySS       (swap ? joy_1[12] : joy_0[12]),
+	.joyRight    (swap ? joy_1[0]  : joy_0[0]),
+	.joyLeft     (swap ? joy_1[1]  : joy_0[1]),
+	.joyDown     (swap ? joy_1[2]  : joy_0[2]),
+	.joyUp       (swap ? joy_1[3]  : joy_0[3]),
+	.joyPause    (swap ? joy_1[6]  : joy_0[6]),
+	.status_slot (status[16:15]),
+	.OSD_saveload({status[62], status[61]}),
+	.selected_slot(ss_slot),
+	.ss_save     (ss_save_raw),
+	.ss_load     (ss_load_raw),
+	.ss_info     (ss_info),
+	.ss_info_req (ss_info_req),
+	.statusUpdate(ss_status)
 );
 
 savestates savestates_inst (

--- a/SMS.sv
+++ b/SMS.sv
@@ -1090,7 +1090,7 @@ system #(63) system
 	.ROMCL(clk_sys),
 	.ROMAD(ioctl_addr),
 	.ROMDT(ioctl_dout),
-	.ROMEN(ioctl_wr & ((ioctl_index[4:0]==1) || (ioctl_index[4:0]==2))),
+	.ROMEN(ioctl_wr & ((ioctl_index[4:0]==0) || (ioctl_index[4:0]==1) || (ioctl_index[4:0]==2))),
 	.BIOSWEN(ioctl_wr & (ioctl_index[4:0]==3)),
 
 	// Save-state interface

--- a/files.qip
+++ b/files.qip
@@ -23,3 +23,5 @@ set_global_assignment -name VHDL_FILE rtl/system.vhd
 set_global_assignment -name VHDL_FILE rtl/io.vhd
 set_global_assignment -name VHDL_FILE rtl/AudioMix.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE SMS.sv
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/savestate_ui.sv
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/savestates.sv

--- a/rtl/T80/T80.vhd
+++ b/rtl/T80/T80.vhd
@@ -121,7 +121,9 @@ entity T80 is
 		REG        : out std_logic_vector(211 downto 0); -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
 
 		DIRSet     : in  std_logic := '0';
-		DIR        : in  std_logic_vector(211 downto 0) := (others => '0') -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+		DIR        : in  std_logic_vector(211 downto 0) := (others => '0'); -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+		-- Prefix/instruction-set state: '00'=no prefix (clean save point)
+		ISet_out   : out std_logic_vector(1 downto 0)
 	);
 end T80;
 
@@ -257,6 +259,8 @@ architecture rtl of T80 is
 	signal DOR                  : std_logic_vector(127 downto 0);
 
 begin
+
+	ISet_out <= ISet;
 
 	REG <= IntE_FF2 & IntE_FF1 & IStatus & DOR & std_logic_vector(PC) & std_logic_vector(SP) & std_logic_vector(R) & I & Fp & Ap & F & ACC when Alternate = '0'
 			 else IntE_FF2 & IntE_FF1 & IStatus & DOR(127 downto 112) & DOR(47 downto 0) & DOR(63 downto 48) & DOR(111 downto 64) &
@@ -415,6 +419,10 @@ begin
 				PC  <= unsigned(DIR(79 downto 64));
 				A   <= DIR(79 downto 64);
 				IStatus <= DIR(209 downto 208);
+				ISet <= "00";
+				XY_State <= "00";
+				XY_Ind <= '0';
+				Alternate <= '0';
 
 			elsif ClkEn = '1' then
 				ALU_Op_r <= "0000";
@@ -1079,6 +1087,22 @@ begin
 			if DIRSet = '1' then
 				IntE_FF2 <= DIR(211);
 				IntE_FF1 <= DIR(210);
+				Halt_FF <= '0';
+				-- Restart from a clean opcode-fetch cycle after state restore.
+				-- Without this, stale MCycle/TState/IR context from pre-load execution
+				-- can continue with restored registers and cause immediate divergence.
+				MCycle <= "001";
+				TState <= "001";
+				M1_n <= '0';
+				IntCycle <= '0';
+				NMICycle <= '0';
+				Pre_XY_F_M <= "000";
+				No_BTR <= '0';
+				Auto_Wait_t1 <= '0';
+				Auto_Wait_t2 <= '0';
+				BusAck <= '0';
+				BusReq_s <= '0';
+				NMI_s <= '0';
 			else
 				if NMI_n = '0' and OldNMI_n = '1' then
 					NMI_s <= '1';

--- a/rtl/T80/T80s.vhd
+++ b/rtl/T80/T80s.vhd
@@ -94,7 +94,14 @@ entity T80s is
 		OUT0        : in  std_logic := '0';  -- 0 => OUT(C),0, 1 => OUT(C),255
 		A				: out std_logic_vector(15 downto 0);
 		DI				: in std_logic_vector(7 downto 0);
-		DO				: out std_logic_vector(7 downto 0)
+		DO				: out std_logic_vector(7 downto 0);
+		-- Save state: snapshot of all Z80 registers
+		-- IFF2,IFF1,IM,IY,HL',DE',BC',IX,HL,DE,BC,PC,SP,R,I,F',A',F,A
+		REG        : out std_logic_vector(211 downto 0);
+		DIRSet     : in  std_logic := '0';
+		DIR        : in  std_logic_vector(211 downto 0) := (others => '0');
+		-- Prefix/instruction-set state forwarded from T80
+		ISet_out   : out std_logic_vector(1 downto 0)
 	);
 end T80s;
 
@@ -136,7 +143,11 @@ begin
 			MC => MCycle,
 			TS => TState,
 			OUT0 => OUT0,
-			IntCycle_n => IntCycle_n
+			IntCycle_n => IntCycle_n,
+			REG => REG,
+			DIRSet => DIRSet,
+			DIR => DIR,
+			ISet_out => ISet_out
 		);
 
 	process (RESET_n, CLK)

--- a/rtl/jt89/jt89.v
+++ b/rtl/jt89/jt89.v
@@ -39,7 +39,12 @@ module jt89(
     input    [7:0] mux,
     output  signed [10:0] soundL,
     output  signed [10:0] soundR,
-    output         ready
+    output         ready,
+    // Save-state snapshot (combinational)
+    output [55:0]  ss_out,   // tone0[9:0], tone1[9:0], tone2[9:0], vol0-3[3:0], ctrl3[2:0], regn[2:0]
+    // Save-state restore (synchronous, held one cycle)
+    input          ss_set,
+    input  [55:0]  ss_in
 );
 
 wire signed [ 8:0] ch0, ch1, ch2, noise;
@@ -82,6 +87,9 @@ always @(posedge clk )
     else if( clk_en )
         clk_div <= clk_div + 1'b1;
 
+// Save-state snapshot: {regn[2:0], ctrl3[2:0], vol3[3:0], vol2[3:0], vol1[3:0], vol0[3:0], tone2[9:0], tone1[9:0], tone0[9:0]}
+assign ss_out = { regn, ctrl3, vol3, vol2, vol1, vol0, tone2, tone1, tone0 };
+
 reg clr_noise, last_wr;
 wire [2:0] reg_sel = din[7] ? din[6:4] : regn;
 
@@ -90,6 +98,18 @@ always @(posedge clk)
         { vol0, vol1, vol2, vol3 } <= {16{1'b1}};
         { tone0, tone1, tone2 } <= 30'd0;
         ctrl3 <= 3'b100;
+        regn  <= 3'd0;
+    end
+    else if( ss_set ) begin
+        tone0 <= ss_in[9:0];
+        tone1 <= ss_in[19:10];
+        tone2 <= ss_in[29:20];
+        vol0  <= ss_in[33:30];
+        vol1  <= ss_in[37:34];
+        vol2  <= ss_in[41:38];
+        vol3  <= ss_in[45:42];
+        ctrl3 <= ss_in[48:46];
+        regn  <= ss_in[51:49];
     end
     else begin
         last_wr <= wr_n;

--- a/rtl/jt89/jt89.vhd
+++ b/rtl/jt89/jt89.vhd
@@ -14,7 +14,11 @@ port
     ready      : out std_logic;
     mux        : in  std_logic_vector(7 downto 0);
     soundL     : out std_logic_vector(10 downto 0); -- signed
-    soundR     : out std_logic_vector(10 downto 0) -- signed
+    soundR     : out std_logic_vector(10 downto 0); -- signed
+    -- Save-state ports
+    ss_out     : out std_logic_vector(55 downto 0);
+    ss_set     : in  std_logic := '0';
+    ss_in      : in  std_logic_vector(55 downto 0) := (others => '0')
 );
 end component;
 

--- a/rtl/savestate_ui.sv
+++ b/rtl/savestate_ui.sv
@@ -1,0 +1,66 @@
+// savestate_ui.sv
+// Translates OSD status bits and PS/2 keyboard shortcuts into
+// one-cycle ss_save / ss_load pulses and slot selection.
+//
+// Slot OSD bits (status[16:15]):  0→slot 1, 1→slot 2, 2→slot 3, 3→slot 4
+// Save trigger  (status[61]):     rising edge → ss_save pulse
+// Load trigger  (status[62]):     rising edge → ss_load pulse
+//
+// Keyboard shortcuts (via MiSTer ps2_key interface):
+//   F1          → load state  (keycode 0x05, not extended)
+//   Alt + F1    → save state  (Left-Alt = 0x11 non-ext, Right-Alt = 0x11 ext)
+// ps2_key[10] = toggle strobe (changes on every key event)
+// ps2_key[9]  = 1 when key pressed, 0 when released
+// ps2_key[8]  = extended key flag
+// ps2_key[7:0]= PS/2 scan-code set 2 key code
+
+module savestate_ui (
+    input             clk,
+    input      [63:0]  status,        // OSD status word from hps_io
+    input      [10:0]  ps2_key,       // PS/2 key from hps_io
+    output reg  [1:0] ss_slot,        // current slot (0-based)
+    output reg        ss_save,        // one-cycle save pulse
+    output reg        ss_load         // one-cycle load pulse
+);
+
+// Slot selection is live from status bits
+always @(posedge clk) begin
+    ss_slot <= status[16:15];
+end
+
+// -----------------------------------------------------------------------
+// PS/2 keyboard shortcuts: F1 = load, Alt+F1 = save
+// -----------------------------------------------------------------------
+reg  ps2_stb;
+reg  alt_held;
+reg  kbd_save, kbd_load;
+
+always @(posedge clk) begin
+    ps2_stb  <= ps2_key[10];
+    kbd_save <= 0;
+    kbd_load <= 0;
+
+    if (ps2_stb ^ ps2_key[10]) begin   // new key event
+        if (ps2_key[7:0] == 8'h11)         // Left-Alt or Right-Alt
+            alt_held <= ps2_key[9];
+        if (ps2_key[7:0] == 8'h05 && ps2_key[9]) begin  // F1 pressed
+            if (alt_held) kbd_save <= 1;
+            else          kbd_load <= 1;
+        end
+    end
+end
+
+// -----------------------------------------------------------------------
+// Edge detectors for OSD save / load triggers; OR with keyboard shortcuts
+// -----------------------------------------------------------------------
+reg old_save, old_load;
+
+always @(posedge clk) begin
+    old_save <= status[61];
+    old_load <= status[62];
+
+    ss_save <= (~old_save & status[61]) | kbd_save;
+    ss_load <= (~old_load & status[62]) | kbd_load;
+end
+
+endmodule

--- a/rtl/savestate_ui.sv
+++ b/rtl/savestate_ui.sv
@@ -1,49 +1,84 @@
-// savestate_ui.sv
-// Translates OSD status bits and PS/2 keyboard shortcuts into
-// one-cycle ss_save / ss_load pulses and slot selection.
+// savestate_ui.sv  (SMS_MiSTer)
 //
-// Slot OSD bits (status[16:15]):  0→slot 1, 1→slot 2, 2→slot 3, 3→slot 4
-// Save trigger  (status[61]):     rising edge → ss_save pulse
-// Load trigger  (status[62]):     rising edge → ss_load pulse
+// Translates OSD status bits, PS/2 keyboard shortcuts, and gamepad button
+// combos into one-cycle ss_save / ss_load pulses and slot selection.
 //
-// Keyboard shortcuts (via MiSTer ps2_key interface):
-//   F1          → load state  (keycode 0x05, not extended)
-//   Alt + F1    → save state  (Left-Alt = 0x11 non-ext, Right-Alt = 0x11 ext)
-// ps2_key[10] = toggle strobe (changes on every key event)
-// ps2_key[9]  = 1 when key pressed, 0 when released
-// ps2_key[8]  = extended key flag
-// ps2_key[7:0]= PS/2 scan-code set 2 key code
+// Info message indices for hps_io (1-based; 0 = no display):
+//   1    : hint message ("Slot=LR|Save=Pause+Down|Load=Pause+Up")
+//   2-5  : "Active Slot 1..4"
+//   6,8,10,12 : "Save to state 1..4"
+//   7,9,11,13 : "Restore state 1..4"
+//
+// Slot OSD bits (status[16:15]): 0→slot 1, 1→slot 2, 2→slot 3, 3→slot 4
+// OSD save  (status[61]):  rising edge → ss_save
+// OSD load  (status[62]):  rising edge → ss_load
+//
+// Gamepad combos (SaveState button = joy[12]):
+//   SS + Left              → switch to prev slot
+//   SS + Right             → switch to next slot
+//   SS + Pause + Down      → save state
+//   SS + Pause + Up        → load state
+//
+// PS/2 keyboard:  F1 = load state,  Alt+F1 = save state
 
 module savestate_ui (
     input             clk,
-    input      [63:0]  status,        // OSD status word from hps_io
-    input      [10:0]  ps2_key,       // PS/2 key from hps_io
-    output reg  [1:0] ss_slot,        // current slot (0-based)
-    output reg        ss_save,        // one-cycle save pulse
-    output reg        ss_load         // one-cycle load pulse
+    input      [63:0] status,        // OSD status word from hps_io
+    input      [10:0] ps2_key,       // PS/2 key interface from hps_io
+    input             allow_ss,      // 1 when savestates are permitted
+    input             joySS,         // SaveState button  (joy[12])
+    input             joyRight,      // joy[0]
+    input             joyLeft,       // joy[1]
+    input             joyDown,       // joy[2]
+    input             joyUp,         // joy[3]
+    input             joyPause,      // joy[6]
+    input       [1:0] status_slot,   // OSD slot selector  (status[16:15])
+    input       [1:0] OSD_saveload,  // {load_bit, save_bit} = status[62:61]
+    output reg  [1:0] selected_slot, // current slot (0-based), drives savestates
+    output reg        ss_save,       // one-cycle save pulse
+    output reg        ss_load,       // one-cycle load pulse
+    output reg  [7:0] ss_info,       // info message index to display
+    output reg        ss_info_req,   // one-cycle: latch ss_info into hps_io
+    output reg        statusUpdate   // one-cycle: push slot back to OSD
 );
 
-// Slot selection is live from status bits
-always @(posedge clk) begin
-    ss_slot <= status[16:15];
-end
+// Internal slot register
+reg [1:0] slot;
+reg [1:0] old_status_slot;
+
+// Two-stage statusUpdate: fires the cycle after slot changes so that
+// selected_slot has already been updated when SMS.sv reads it.
+reg statusUpdate_pending;
+
+// PS/2 state
+reg ps2_stb;
+reg alt_held;
+reg kbd_save, kbd_load;
+
+// Joystick edge trackers
+reg joyLeft_r, joyRight_r, joyDown_r, joyUp_r, joySS_r;
+
+// SS hold-to-hint timer (~2.5s at 53.693 MHz = clk_sys)
+// bit 27 trips at 2^27 = 134 M cycles
+localparam SS_HINT_BITS = 27;
+reg [SS_HINT_BITS:0] ss_hold_cnt;   // 28-bit up-counter
+reg                  ss_combo_done; // combo or timeout already fired this press
+
+// OSD edge trackers
+reg old_osd_save, old_osd_load;
 
 // -----------------------------------------------------------------------
-// PS/2 keyboard shortcuts: F1 = load, Alt+F1 = save
+// PS/2 keyboard: F1 = load,  Alt+F1 = save
 // -----------------------------------------------------------------------
-reg  ps2_stb;
-reg  alt_held;
-reg  kbd_save, kbd_load;
-
 always @(posedge clk) begin
     ps2_stb  <= ps2_key[10];
     kbd_save <= 0;
     kbd_load <= 0;
 
-    if (ps2_stb ^ ps2_key[10]) begin   // new key event
-        if (ps2_key[7:0] == 8'h11)         // Left-Alt or Right-Alt
+    if (ps2_stb ^ ps2_key[10]) begin
+        if (ps2_key[7:0] == 8'h11)
             alt_held <= ps2_key[9];
-        if (ps2_key[7:0] == 8'h05 && ps2_key[9]) begin  // F1 pressed
+        if (ps2_key[7:0] == 8'h05 && ps2_key[9]) begin
             if (alt_held) kbd_save <= 1;
             else          kbd_load <= 1;
         end
@@ -51,16 +86,115 @@ always @(posedge clk) begin
 end
 
 // -----------------------------------------------------------------------
-// Edge detectors for OSD save / load triggers; OR with keyboard shortcuts
+// Main logic: OSD / keyboard / gamepad
 // -----------------------------------------------------------------------
-reg old_save, old_load;
-
 always @(posedge clk) begin
-    old_save <= status[61];
-    old_load <= status[62];
+    // Defaults
+    ss_save              <= 0;
+    ss_load              <= 0;
+    ss_info_req          <= 0;
+    statusUpdate         <= statusUpdate_pending; // fire 1 cycle after slot change
+    statusUpdate_pending <= 0;
 
-    ss_save <= (~old_save & status[61]) | kbd_save;
-    ss_load <= (~old_load & status[62]) | kbd_load;
+    // Latch joystick edges
+    joySS_r    <= joySS;
+    joyLeft_r  <= joyLeft;
+    joyRight_r <= joyRight;
+    joyDown_r  <= joyDown;
+    joyUp_r    <= joyUp;
+
+    // Rising edge of SS: show current slot; start hold-to-hint timer
+    if (~joySS_r & joySS) begin
+        ss_info_req   <= 1;
+        ss_info       <= 8'd2 + slot;  // "Active Slot N"
+        ss_hold_cnt   <= 0;
+        ss_combo_done <= 0;
+    end
+
+    // SS held without action: count up; show hint after ~2.5s
+    if (joySS & joySS_r & ~ss_combo_done) begin
+        if (ss_hold_cnt[SS_HINT_BITS]) begin
+            ss_info_req   <= 1;
+            ss_info       <= 8'd1;     // hint
+            ss_combo_done <= 1;
+        end else
+            ss_hold_cnt   <= ss_hold_cnt + 1'd1;
+    end
+
+    // Falling edge of SS: show hint only if no combo/timeout occurred
+    if (joySS_r & ~joySS & ~ss_combo_done) begin
+        ss_info_req <= 1;
+        ss_info     <= 8'd1;           // hint
+    end
+
+    // Sync slot when user changes it through the OSD menu
+    old_status_slot <= status_slot;
+    if (status_slot != old_status_slot)
+        slot <= status_slot;
+
+    // selected_slot tracks slot with 1-cycle lag; aligned with statusUpdate
+    selected_slot <= slot;
+
+    // OSD save/load (status[61]=save, status[62]=load)
+    old_osd_save <= OSD_saveload[0];
+    old_osd_load <= OSD_saveload[1];
+
+    if (~old_osd_save & OSD_saveload[0] & allow_ss) begin
+        ss_save     <= 1;
+        ss_info_req <= 1;
+        ss_info     <= 8'd6 + {slot, 1'b0};   // "Save to state N"  (1-based: 6,8,10,12)
+    end
+    if (~old_osd_load & OSD_saveload[1] & allow_ss) begin
+        ss_load     <= 1;
+        ss_info_req <= 1;
+        ss_info     <= 8'd7 + {slot, 1'b0};   // "Restore state N"  (1-based: 7,9,11,13)
+    end
+
+    // PS/2 keyboard shortcuts
+    if (kbd_save & allow_ss) begin
+        ss_save     <= 1;
+        ss_info_req <= 1;
+        ss_info     <= 8'd6 + {slot, 1'b0};
+    end
+    if (kbd_load & allow_ss) begin
+        ss_load     <= 1;
+        ss_info_req <= 1;
+        ss_info     <= 8'd7 + {slot, 1'b0};
+    end
+
+    // Gamepad combos — only when the dedicated SaveState button is held
+    if (joySS) begin
+        // Rising edge of Left (no Pause): previous slot
+        if (~joyLeft_r & joyLeft & ~joyPause) begin
+            slot                 <= (slot == 2'd0) ? 2'd3 : slot - 2'd1;
+            statusUpdate_pending <= 1;
+            ss_info_req          <= 1;
+            ss_info              <= 8'd2 + ((slot == 2'd0) ? 2'd3 : slot - 2'd1);
+            ss_combo_done        <= 1;
+        end
+        // Rising edge of Right (no Pause): next slot
+        if (~joyRight_r & joyRight & ~joyPause) begin
+            slot                 <= (slot == 2'd3) ? 2'd0 : slot + 2'd1;
+            statusUpdate_pending <= 1;
+            ss_info_req          <= 1;
+            ss_info              <= 8'd2 + ((slot == 2'd3) ? 2'd0 : slot + 2'd1);
+            ss_combo_done        <= 1;
+        end
+        // Rising edge of Down while Pause held: save
+        if (joyPause & ~joyDown_r & joyDown & allow_ss) begin
+            ss_save       <= 1;
+            ss_info_req   <= 1;
+            ss_info       <= 8'd6 + {slot, 1'b0};
+            ss_combo_done <= 1;
+        end
+        // Rising edge of Up while Pause held: load
+        if (joyPause & ~joyUp_r & joyUp & allow_ss) begin
+            ss_load       <= 1;
+            ss_info_req   <= 1;
+            ss_info       <= 8'd7 + {slot, 1'b0};
+            ss_combo_done <= 1;
+        end
+    end
 end
 
 endmodule

--- a/rtl/savestates.sv
+++ b/rtl/savestates.sv
@@ -1,0 +1,899 @@
+// savestates.sv
+// Pure-hardware save-state FSM for SMS_MiSTer.
+//
+// Memory layout (DDRAM word addresses, slot n base = 0x3E000000 + n*0x10000):
+//   Word 0x000: MiSTer SS control word [31:0]=change_det, [63:32]=size_in_32b_words
+//   Word 0x001: magic "SMS1" (0x534D5331)
+//   Word 0x002-0x005: Z80 REG[211:0]   (4 × 64-bit words, MSBs unused)
+//   Word 0x006-0x007: VDP regs [127:0] (2 × 64-bit words)
+//   Word 0x008-0x00D: CRAM [383:0]     (6 × 64-bit words)
+//   Word 0x00E:       PSG  [55:0]      (1 × 64-bit word, upper 8 bits unused)
+//   Word 0x00F:       Mapper [63:0]    (1 × 64-bit word)
+//   Words 0x101-0x900: VRAM 16KB       (2048 × 64-bit words)
+//   Words 0x901-0xD00: WRAM 8KB        (1024 × 64-bit words)
+//   Words 0xD01-0x1100: NVRAM 8KB (Dahjee A only)
+//
+// Slot size = 0x2000 words = 64KB.  Up to 4 slots.
+// Base word address = 29'h07C00000 + slot * 29'h2000
+
+module savestates (
+    input             clk,
+    input             reset_n,
+
+    // Trigger interface (from savestate_ui)
+    input             ss_save,         // one-cycle save pulse
+    input             ss_load,         // one-cycle load pulse
+    input       [1:0] ss_slot,
+    input             ss_bios_mode,    // 1 when running BIOS without cart
+
+    // Freeze: hold '1' to pause CPU + VDP clock enables
+    output reg        ss_freeze,
+
+    // VBlank level from video.vhd (not gated by ss_freeze)
+    // Used to defer unfreeze until a clean frame boundary after load
+    input             vblank,
+
+    // ---- Z80 snapshot / restore ----
+    input     [211:0] z80_reg,         // live snapshot from T80s
+    output reg [211:0] z80_dir,        // restore data
+    output reg        z80_set,         // one-cycle restore strobe
+    input             z80_m1_n,        // Z80 M1 cycle (low = opcode fetch in progress)
+    // '0' = memory request = normal opcode fetch; '1' = interrupt acknowledge (skip!)
+    input             z80_mreq_n,
+    // "00" = no active prefix = clean instruction boundary (safe to save)
+    input       [1:0] z80_iset,
+    // Raw CPU clock-enable pulse (ungated by ss_freeze)
+    input             cpu_ce,
+    // Raw VDP clock-enable pulse (ungated by ss_freeze)
+    input             vdp_ce,
+
+    // ---- VDP registers ----
+    input     [127:0] vdp_regs,
+    output reg [127:0] vdp_regs_in,
+    output reg        vdp_regs_set,
+
+    // ---- CRAM ----
+    input     [383:0] cram_out,
+    output reg  [4:0] cram_A,
+    output reg [11:0] cram_D,
+    output reg        cram_wr,
+
+    // ---- VRAM DMA (port A of dpram in vdp, muxed when freeze) ----
+    output reg        vram_en,         // take over port A for reads
+    output reg [14:0] vram_A,          // read address
+    input       [7:0] vram_D,          // read data (2-cycle latency after vram_A changes)
+    output reg        vram_WE,
+    output reg [14:0] vram_WA,
+    output reg  [7:0] vram_WD,
+
+    // ---- PSG snapshot / restore ----
+    input      [55:0] psg_out,
+    output reg [55:0] psg_in,
+    output reg        psg_set,
+
+    // ---- Mapper snapshot / restore ----
+    input      [63:0] mapper_out,
+    output reg [63:0] mapper_in,
+    output reg        mapper_set,
+
+    // ---- Work RAM DMA (second port of a dpram) ----
+    output reg [13:0] wram_A,          // read address (byte)
+    input       [7:0] wram_D,          // read data
+    output reg        wram_WE,
+    output reg [13:0] wram_WA,
+    output reg  [7:0] wram_WD,
+
+    // ---- NVRAM DMA (Dahjee A expansion RAM, 8KB at $2000-$3FFF) ----
+    // Only saved/restored when mapper_snap[48] (detect_dahjee_a) is set.
+    output reg [12:0] nvram_A,          // read address
+    input       [7:0] nvram_D,          // read data
+    output reg        nvram_WE,
+    output reg [12:0] nvram_WA,
+    output reg  [7:0] nvram_WD,
+
+    // ---- DDRAM interface ----
+    output reg [28:0] DDRAM_ADDR,
+    output reg [63:0] DDRAM_DIN,
+    output reg  [7:0] DDRAM_BE,
+    output reg        DDRAM_WE,
+    input      [63:0] DDRAM_DOUT,
+    input             DDRAM_DOUT_READY,
+    output reg        DDRAM_RD,
+    output reg  [7:0] DDRAM_BURSTCNT,
+    input             DDRAM_BUSY
+);
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+localparam [31:0] MAGIC = 32'h534D5331; // "SMS1"
+localparam [31:0] MAGIC_BIOS = 32'h534D5342; // "SMSB"
+
+// Slot base word address for cartridge savestates (slots 0-3)
+function automatic [28:0] slot_base;
+    input [1:0] slot;
+    slot_base = 29'h07C00000 + {27'd0, slot} * 29'h2000;
+endfunction
+
+// Slot base word address for BIOS savestates (slots 4-7).
+// Placed after the 4 game slots so game and BIOS state never share the same
+// DDRAM words. Addresses here are outside the CONF_STR SS range so the
+// MiSTer ARM side will not write them to disk -- BIOS states are DDRAM-only.
+function automatic [28:0] bios_slot_base;
+    input [1:0] slot;
+    bios_slot_base = 29'h07C08000 + {27'd0, slot} * 29'h2000;
+endfunction
+
+// -----------------------------------------------------------------------
+// State machine
+// -----------------------------------------------------------------------
+localparam ST_IDLE         = 6'd0;
+localparam ST_WAIT_BOUNDARY= 6'd37;  // wait for Z80 instruction boundary (M1)
+localparam ST_ARM_FREEZE   = 6'd41;  // assert freeze so it is active before next CE pulse
+localparam ST_FREEZE       = 6'd1;
+localparam ST_SAVE_HDR     = 6'd2;
+localparam ST_SAVE_CPU0    = 6'd3;
+localparam ST_SAVE_CPU1    = 6'd4;
+localparam ST_SAVE_CPU2    = 6'd5;
+localparam ST_SAVE_CPU3    = 6'd6;
+localparam ST_SAVE_VDP0    = 6'd7;
+localparam ST_SAVE_VDP1    = 6'd8;
+localparam ST_SAVE_CRAM0   = 6'd9;
+// CRAM is 6 words (SAVE_CRAM0 .. SAVE_CRAM5 via cram_idx counter)
+localparam ST_SAVE_PSG     = 6'd15;
+localparam ST_SAVE_MAPPER  = 6'd16;
+localparam ST_SAVE_VRAM    = 6'd17;
+localparam ST_SAVE_WRAM    = 6'd18;
+localparam ST_SAVE_DONE    = 6'd19;
+
+localparam ST_LOAD_HDR_RD  = 6'd20;
+localparam ST_LOAD_HDR_WT  = 6'd21;
+localparam ST_LOAD_CPU0    = 6'd22;
+localparam ST_LOAD_CPU1    = 6'd23;
+localparam ST_LOAD_CPU2    = 6'd24;
+localparam ST_LOAD_CPU3    = 6'd25;
+localparam ST_LOAD_VDP0    = 6'd26;
+localparam ST_LOAD_VDP1    = 6'd27;
+localparam ST_LOAD_CRAM    = 6'd28;  // streams 32 × 12-bit entries via cram_A/D/wr
+localparam ST_LOAD_PSG     = 6'd29;
+localparam ST_LOAD_MAPPER  = 6'd30;
+localparam ST_LOAD_VRAM    = 6'd31;
+localparam ST_LOAD_WRAM    = 6'd32;
+localparam ST_LOAD_RESTORE = 6'd33;
+localparam ST_UNFREEZE     = 6'd34;
+localparam ST_SAVE_NVRAM   = 6'd35;
+localparam ST_LOAD_NVRAM   = 6'd36;
+localparam ST_WAIT_VBLANK  = 6'd38;  // wait for VBlank before unfreeze (load path)
+localparam ST_WAIT_RESTORE_BOUNDARY = 6'd39;  // one-cycle mapper-settle phase before core restore
+localparam ST_ERROR        = 6'd40;  // error state - unfreeze and return to idle
+
+reg [5:0]  state;
+reg        do_save;     // 1=save, 0=load
+reg [1:0]  cur_slot;
+reg [28:0] base_addr;
+reg [31:0] ss_change_det; // MiSTer framework change detector (increment to trigger save-to-disk)
+reg [31:0] cur_magic;
+reg        cur_bios_mode;
+
+// counters
+reg [10:0] word_cnt;    // general DMA word counter
+reg  [2:0] cram_idx;    // 0..5 for CRAM 64-bit words
+reg  [4:0] cram_entry;  // 0..31 for entry-by-entry restore
+reg  [2:0] cpu_idx;     // 0..3 for CPU words
+reg  [2:0] vdp_idx;     // 0..1 for VDP reg words
+// Latching buffers for multi-word state
+reg [211:0] z80_snap;
+reg [127:0] vdp_snap;
+reg [383:0] cram_snap;
+reg  [55:0] psg_snap;
+reg  [63:0] mapper_snap;
+
+// VRAM DMA pipelining: address issued, wait 2 clocks for data
+reg  [2:0]  vram_pipe;
+reg [14:0]  vram_save_addr;  // current byte address being saved
+reg [14:0]  vram_load_addr;  // current byte address being loaded
+reg  [2:0]  vram_byte_cnt;   // 0..7 bytes within 64-bit DDRAM word
+reg [63:0]  vram_word_buf;   // accumulate 8 bytes → 1 DDRAM write
+reg         vram_load_active; // 1 while writing 8 bytes from dout_latch
+// Byte-7 latch: when DDRAM_BUSY stalls a word write, the SPRAM/DPRAM pipeline
+// still advances on the next cycle so vram_D would have wrong data on retry.
+// We latch the correct byte-7 value on the first stall cycle and use it on retry.
+reg  [7:0]  vram_d_latch;
+reg         vram_d_latched;  // 1 = latch holds a valid stalled byte-7 value
+
+// WRAM DMA similar
+reg [13:0]  wram_save_addr;
+reg [13:0]  wram_load_addr;
+reg  [2:0]  wram_byte_cnt;
+reg [63:0]  wram_word_buf;
+reg  [1:0]  wram_pipe;
+reg         wram_load_active; // 1 while writing 8 bytes from dout_latch
+reg  [7:0]  wram_d_latch;
+reg         wram_d_latched;
+
+// NVRAM DMA (8KB Dahjee A expansion RAM)
+reg [12:0]  nvram_save_addr;
+reg [12:0]  nvram_load_addr;
+reg  [2:0]  nvram_byte_cnt;
+reg [63:0]  nvram_word_buf;
+reg  [1:0]  nvram_pipe;
+reg         nvram_load_active;
+reg  [7:0]  nvram_d_latch;
+reg         nvram_d_latched;
+
+// Shared latch for DDRAM read data (LOAD path)
+reg [63:0]  dout_latch;
+
+// Guard flag: set when a ddram_read is issued, cleared when DOUT_READY is consumed.
+// Prevents stale DOUT_READY pulses (from pre-freeze scaler reads) from
+// being misinterpreted as responses to our own load-path read requests.
+reg         dout_expected;
+
+// Watchdog: if a DDRAM read is outstanding for > ~640ms (25-bit @ ~53MHz)
+// we abort to ST_ERROR so the FSM never hangs forever.
+// ~2^25 / 53e6 ≈ 630 ms -- far longer than any real DDRAM latency.
+reg [24:0]  ddram_watchdog;
+localparam  DDRAM_WATCHDOG_MAX = 25'h1FFFFFF;
+
+// VBlank edge-detection for clean unfreeze
+reg         vblank_seen;   // goes 1 once we have seen vblank=1 in ST_WAIT_VBLANK
+
+// -----------------------------------------------------------------------
+// DDRAM helper tasks (inline)
+// -----------------------------------------------------------------------
+task ddram_write;
+    input [28:0] addr;
+    input [63:0] din;
+    input  [7:0] be;
+    begin
+        DDRAM_ADDR     <= addr;
+        DDRAM_DIN      <= din;
+        DDRAM_BE       <= be;
+        DDRAM_WE       <= 1;
+        DDRAM_RD       <= 0;
+        DDRAM_BURSTCNT <= 8'd1;
+    end
+endtask
+
+task ddram_read;
+    input [28:0] addr;
+    begin
+        DDRAM_ADDR     <= addr;
+        DDRAM_BE       <= 8'hFF;
+        DDRAM_WE       <= 0;
+        DDRAM_RD       <= 1;
+        DDRAM_BURSTCNT <= 8'd1;
+        dout_expected  <= 1;   // mark that a response is in flight
+    end
+endtask
+
+task ddram_idle;
+    begin
+        DDRAM_WE <= 0;
+        DDRAM_RD <= 0;
+    end
+endtask
+
+// -----------------------------------------------------------------------
+// Main FSM
+// -----------------------------------------------------------------------
+always @(posedge clk or negedge reset_n) begin
+    if (!reset_n) begin
+        state           <= ST_IDLE;
+        ss_freeze       <= 0;
+        ss_change_det   <= 0;
+        cur_magic       <= MAGIC;
+        cur_bios_mode   <= 0;
+        z80_set         <= 0;
+        vdp_regs_set    <= 0;
+        cram_wr         <= 0;
+        psg_set         <= 0;
+        mapper_set      <= 0;
+        vram_en         <= 0;
+        vram_WE         <= 0;
+        vram_load_active <= 0;
+        wram_WE         <= 0;
+        wram_load_active <= 0;
+        nvram_WE        <= 0;
+        nvram_load_active <= 0;
+        dout_latch      <= 64'd0;
+        vblank_seen     <= 0;
+        dout_expected   <= 0;
+        ddram_watchdog  <= 0;
+        DDRAM_WE        <= 0;
+        DDRAM_RD        <= 0;
+        DDRAM_BURSTCNT  <= 8'd1;
+    end else begin
+        // default: clear one-cycle strobes
+        z80_set      <= 0;
+        vdp_regs_set <= 0;
+        cram_wr      <= 0;
+        psg_set      <= 0;
+        mapper_set   <= 0;
+        vram_WE      <= 0;
+        wram_WE      <= 0;
+        nvram_WE     <= 0;
+        ddram_idle();
+
+        // DDRAM read watchdog: abort if no response after ~640ms
+        if (dout_expected) begin
+            if (ddram_watchdog == DDRAM_WATCHDOG_MAX) begin
+                dout_expected  <= 0;
+                ddram_watchdog <= 0;
+                state          <= ST_ERROR;
+            end else
+                ddram_watchdog <= ddram_watchdog + 25'd1;
+        end else
+            ddram_watchdog <= 0;
+
+        case (state)
+        // ---------------------------------------------------------------
+        ST_IDLE: begin
+            ss_freeze   <= 0;
+            vblank_seen <= 0;  // reset for next VBlank wait
+            if (ss_save) begin
+                do_save   <= 1;
+                cur_slot  <= ss_slot;
+                state     <= ST_WAIT_BOUNDARY;
+            end else if (ss_load) begin
+                do_save   <= 0;
+                cur_slot  <= ss_slot;
+                state     <= ST_WAIT_BOUNDARY;
+            end
+        end
+
+        // ---------------------------------------------------------------
+        ST_WAIT_BOUNDARY: begin
+            // Wait for a clean Z80 instruction boundary:
+            //   - M1_n low  : opcode-fetch machine cycle
+            //   - MREQ_n low: normal memory read (not interrupt acknowledge)
+            //   - ISet=00   : no prefix active (not mid-way through CB/DD/ED/FD sequence)
+            //   - cpu_ce     : only act on an actual CPU tick, not on held bus
+            //                  levels between ticks.
+            if (cpu_ce && !z80_m1_n && !z80_mreq_n && z80_iset == 2'b00) begin
+                base_addr <= ss_bios_mode ? bios_slot_base(cur_slot) : slot_base(cur_slot);
+                cur_bios_mode <= ss_bios_mode;
+                cur_magic <= ss_bios_mode ? MAGIC_BIOS : MAGIC;
+
+                // Capture snapshot in the same cycle the boundary is detected.
+                // Capturing one cycle later can occasionally grab post-boundary
+                // state (or partially advanced mapper/VDP side effects), creating
+                // non-deterministic loads that crash or glitch.
+                z80_snap    <= z80_reg;
+                vdp_snap    <= vdp_regs;
+                cram_snap   <= cram_out;
+                psg_snap    <= psg_out;
+                mapper_snap <= mapper_out;
+                state       <= ST_ARM_FREEZE;
+            end
+        end
+
+        // ---------------------------------------------------------------
+        ST_ARM_FREEZE: begin
+            // Freeze is asserted one clk_sys cycle after boundary detection so
+            // it is guaranteed active before the next CPU/VDP CE pulse.
+            // This prevents one extra micro-step after snapshot capture.
+            ss_freeze <= 1;
+            state     <= ST_FREEZE;
+        end
+
+        // ---------------------------------------------------------------
+        ST_FREEZE: begin
+            ss_freeze <= 1;
+            state <= do_save ? ST_SAVE_HDR : ST_LOAD_HDR_RD;
+        end
+
+        // ---------------------------------------------------------------
+        ST_WAIT_RESTORE_BOUNDARY: begin
+            // Restore mapper/bank state first and give it one full clk_sys cycle
+            // to settle before loading CPU/VDP/PSG. This avoids occasional
+            // resumes with stale ROM mapping or BIOS/cart decode for the first
+            // restored core cycle.
+            mapper_in  <= mapper_snap;
+            mapper_set <= 1;
+            state      <= ST_LOAD_RESTORE;
+        end
+
+        // ===============================================================
+        // SAVE
+        // ===============================================================
+
+        ST_SAVE_HDR: begin
+            if (!DDRAM_BUSY) begin
+                ddram_write(base_addr + 29'd1, {32'd0, cur_magic}, 8'h0F);
+                state <= ST_SAVE_CPU0;
+                cpu_idx <= 0;
+            end
+        end
+
+        ST_SAVE_CPU0: begin
+            // z80_snap[211:0] = 212 bits → 4 × 64-bit words (w0..w2 = 192 bits + w3 spare 20 bits)
+            if (!DDRAM_BUSY) begin
+                case (cpu_idx)
+                    3'd0: ddram_write(base_addr + 29'd2, z80_snap[63:0],    8'hFF);
+                    3'd1: ddram_write(base_addr + 29'd3, z80_snap[127:64],  8'hFF);
+                    3'd2: ddram_write(base_addr + 29'd4, z80_snap[191:128], 8'hFF);
+                    3'd3: ddram_write(base_addr + 29'd5, {52'd0, z80_snap[211:192]}, 8'hFF);
+                endcase
+                if (cpu_idx == 3) begin
+                    state   <= ST_SAVE_VDP0;
+                    vdp_idx <= 0;
+                end else
+                    cpu_idx <= cpu_idx + 3'd1;
+            end
+        end
+
+        ST_SAVE_VDP0: begin
+            if (!DDRAM_BUSY) begin
+                case (vdp_idx[0])
+                    1'b0: ddram_write(base_addr + 29'd6, vdp_snap[63:0],   8'hFF);
+                    1'b1: ddram_write(base_addr + 29'd7, vdp_snap[127:64], 8'hFF);
+                endcase
+                if (vdp_idx[0] == 1) begin
+                    state    <= ST_SAVE_CRAM0;
+                    cram_idx <= 0;
+                end else
+                    vdp_idx[0] <= 1'b1;
+            end
+        end
+
+        ST_SAVE_CRAM0: begin
+            // cram_snap[383:0] = 6 × 64 bits
+            if (!DDRAM_BUSY) begin
+                case (cram_idx)
+                    3'd0: ddram_write(base_addr + 29'd8,  cram_snap[63:0],    8'hFF);
+                    3'd1: ddram_write(base_addr + 29'd9,  cram_snap[127:64],  8'hFF);
+                    3'd2: ddram_write(base_addr + 29'd10, cram_snap[191:128], 8'hFF);
+                    3'd3: ddram_write(base_addr + 29'd11, cram_snap[255:192], 8'hFF);
+                    3'd4: ddram_write(base_addr + 29'd12, cram_snap[319:256], 8'hFF);
+                    3'd5: ddram_write(base_addr + 29'd13, cram_snap[383:320], 8'hFF);
+                    default: ;
+                endcase
+                if (cram_idx == 5)
+                    state <= ST_SAVE_PSG;
+                else
+                    cram_idx <= cram_idx + 3'd1;
+            end
+        end
+
+        ST_SAVE_PSG: begin
+            if (!DDRAM_BUSY) begin
+                ddram_write(base_addr + 29'd14, {8'd0, psg_snap}, 8'hFF);
+                state <= ST_SAVE_MAPPER;
+            end
+        end
+
+        ST_SAVE_MAPPER: begin
+            if (!DDRAM_BUSY) begin
+                ddram_write(base_addr + 29'd15, mapper_snap, 8'hFF);
+                // Start VRAM DMA: 16384 bytes → 2048 × 64-bit words
+                // DDRAM offset 0x100 words from base
+                vram_save_addr <= 0;
+                vram_byte_cnt  <= 0;
+                vram_word_buf  <= 0;
+                vram_pipe      <= 0;
+                vram_en        <= 1;
+                vram_A         <= 0;
+                word_cnt       <= 0;
+                vram_d_latched <= 0;
+                state          <= ST_SAVE_VRAM;
+            end
+        end
+
+        ST_SAVE_VRAM: begin
+            // Pipeline: issue address on cycle 0, data is ready 2 cycles later
+            vram_en <= 1;
+            if (vram_pipe < 3'd2) begin
+                // Prime the pipeline: advance address each cycle
+                vram_pipe <= vram_pipe + 3'd1;
+                if (vram_pipe >= 1 && vram_save_addr < 15'd16384)
+                    vram_A <= vram_save_addr + 15'd1;
+            end else begin
+                // Stall entire pipeline at 8-byte word boundary if DDRAM is busy.
+                // Holding all signals stable means vram_D (and word_buf) remain
+                // valid so the write can be retried on the next cycle.
+                if (vram_byte_cnt < 7 || !DDRAM_BUSY) begin
+                    // On first arrival at byte 7 after a stall the SPRAM
+                    // pipeline has already advanced one address, so vram_D
+                    // now holds the NEXT byte – use the value we latched on
+                    // the stall cycle instead.
+                    vram_d_latched <= 0;   // clear for next word
+                    vram_word_buf <= {(vram_byte_cnt == 7 && vram_d_latched) ? vram_d_latch : vram_D,
+                                      vram_word_buf[63:8]};
+                    vram_byte_cnt <= vram_byte_cnt + 3'd1;
+                    if (vram_byte_cnt == 7) begin
+                        ddram_write(base_addr + 29'h101 + {18'd0, word_cnt},
+                                    {vram_d_latched ? vram_d_latch : vram_D,
+                                     vram_word_buf[63:8]}, 8'hFF);
+                        word_cnt <= word_cnt + 11'd1;
+                    end
+                    // Advance address pipeline
+                    if (vram_save_addr < 15'd16383) begin
+                        vram_save_addr <= vram_save_addr + 15'd1;
+                        vram_A         <= vram_save_addr + 15'd2;
+                    end else if (vram_byte_cnt == 7) begin
+                        vram_en <= 0;
+                        // Start WRAM DMA
+                        wram_save_addr <= 0;
+                        wram_byte_cnt  <= 0;
+                        wram_word_buf  <= 0;
+                        wram_pipe      <= 0;
+                        wram_A         <= 0;
+                        word_cnt       <= 0;
+                        wram_d_latched <= 0;
+                        state          <= ST_SAVE_WRAM;
+                    end
+                end else begin
+                    // DDRAM busy at boundary: latch byte-7 on the first
+                    // stall cycle before the SPRAM pipeline advances.
+                    if (!vram_d_latched) begin
+                        vram_d_latch   <= vram_D;
+                        vram_d_latched <= 1;
+                    end
+                end
+            end
+        end
+
+        ST_SAVE_WRAM: begin
+            if (wram_pipe < 2'd2) begin
+                wram_pipe <= wram_pipe + 2'd1;
+                if (wram_pipe >= 1 && wram_save_addr < 14'd8191)
+                    wram_A <= wram_save_addr + 14'd1;
+            end else begin
+                // Stall at 8-byte boundary if DDRAM is busy (same pattern as VRAM)
+                if (wram_byte_cnt < 7 || !DDRAM_BUSY) begin
+                    wram_d_latched <= 0;
+                    wram_word_buf <= {(wram_byte_cnt == 7 && wram_d_latched) ? wram_d_latch : wram_D,
+                                      wram_word_buf[63:8]};
+                    wram_byte_cnt <= wram_byte_cnt + 3'd1;
+                    if (wram_byte_cnt == 7) begin
+                        ddram_write(base_addr + 29'h901 + {18'd0, word_cnt},
+                                    {wram_d_latched ? wram_d_latch : wram_D,
+                                     wram_word_buf[63:8]}, 8'hFF);
+                        word_cnt <= word_cnt + 11'd1;
+                    end
+                    if (wram_save_addr < 14'd8191) begin
+                        wram_save_addr <= wram_save_addr + 14'd1;
+                        wram_A         <= wram_save_addr + 14'd2;
+                    end else if (wram_byte_cnt == 7) begin
+                        if (mapper_snap[48]) begin
+                            // Dahjee A: save 8KB nvram (expansion RAM at $2000-$3FFF)
+                            nvram_save_addr <= 0;
+                            nvram_byte_cnt  <= 0;
+                            nvram_word_buf  <= 0;
+                            nvram_pipe      <= 0;
+                            nvram_A         <= 0;
+                            word_cnt        <= 0;
+                            nvram_d_latched <= 0;
+                            state           <= ST_SAVE_NVRAM;
+                        end else begin
+                            state <= ST_SAVE_DONE;
+                        end
+                    end
+                end else begin
+                    if (!wram_d_latched) begin
+                        wram_d_latch   <= wram_D;
+                        wram_d_latched <= 1;
+                    end
+                end
+            end
+        end
+
+        ST_SAVE_NVRAM: begin
+            if (nvram_pipe < 2'd2) begin
+                nvram_pipe <= nvram_pipe + 2'd1;
+                if (nvram_pipe >= 1 && nvram_save_addr < 13'd8191)
+                    nvram_A <= nvram_save_addr + 13'd1;
+            end else begin
+                // Stall at 8-byte boundary if DDRAM is busy (same pattern as VRAM/WRAM)
+                if (nvram_byte_cnt < 7 || !DDRAM_BUSY) begin
+                    nvram_d_latched <= 0;
+                    nvram_word_buf <= {(nvram_byte_cnt == 7 && nvram_d_latched) ? nvram_d_latch : nvram_D,
+                                       nvram_word_buf[63:8]};
+                    nvram_byte_cnt <= nvram_byte_cnt + 3'd1;
+                    if (nvram_byte_cnt == 7) begin
+                        ddram_write(base_addr + 29'h0D01 + {18'd0, word_cnt},
+                                    {nvram_d_latched ? nvram_d_latch : nvram_D,
+                                     nvram_word_buf[63:8]}, 8'hFF);
+                        word_cnt <= word_cnt + 11'd1;
+                    end
+                    if (nvram_save_addr < 13'd8191) begin
+                        nvram_save_addr <= nvram_save_addr + 13'd1;
+                        nvram_A         <= nvram_save_addr + 13'd2;
+                    end else if (nvram_byte_cnt == 7) begin
+                        state <= ST_SAVE_DONE;
+                    end
+                end else begin
+                    if (!nvram_d_latched) begin
+                        nvram_d_latch   <= nvram_D;
+                        nvram_d_latched <= 1;
+                    end
+                end
+            end
+        end
+
+        ST_SAVE_DONE: begin
+            // Write MiSTer framework control word at slot base (word 0).
+            // [31:0]  = change_det: must change on every save to trigger firmware write to /savestates/
+            // [63:32] = size in 32-bit words = (slot_size_bytes - 8) / 4
+            //           slot = 64KB = 65536 bytes; minus 8-byte control word = 65528 bytes → 16382 words
+            if (cur_bios_mode) begin
+                // BIOS states live in their own DDRAM region (bios_slot_base);
+                // no change_det write → ARM never saves them to disk, so they
+                // cannot contaminate the last-loaded game's .ss file.
+                state <= ST_UNFREEZE;
+            end else if (!DDRAM_BUSY) begin
+                ddram_write(base_addr + 29'd0, {32'd16382, ss_change_det}, 8'hFF);
+                ss_change_det <= ss_change_det + 32'd1;
+                state <= ST_UNFREEZE;
+            end
+        end
+
+        // ===============================================================
+        // LOAD
+        // ===============================================================
+
+        ST_LOAD_HDR_RD: begin
+            if (!DDRAM_BUSY) begin
+                ddram_read(base_addr + 29'd1);
+                state <= ST_LOAD_HDR_WT;
+            end
+        end
+
+        ST_LOAD_HDR_WT: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                if (DDRAM_DOUT[31:0] == cur_magic) begin
+                    // Read Z80 words
+                    ddram_read(base_addr + 29'd2);
+                    cpu_idx <= 0;
+                    state   <= ST_LOAD_CPU0;
+                end else begin
+                    // Invalid magic: abort
+                    state <= ST_UNFREEZE;
+                end
+            end
+        end
+
+        ST_LOAD_CPU0: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                case (cpu_idx)
+                    3'd0: begin z80_dir[63:0]    <= DDRAM_DOUT; ddram_read(base_addr + 29'd3); end
+                    3'd1: begin z80_dir[127:64]  <= DDRAM_DOUT; ddram_read(base_addr + 29'd4); end
+                    3'd2: begin z80_dir[191:128] <= DDRAM_DOUT; ddram_read(base_addr + 29'd5); end
+                    3'd3: begin z80_dir[211:192] <= DDRAM_DOUT[19:0]; ddram_read(base_addr + 29'd6); end
+                endcase
+                if (cpu_idx == 3) begin
+                    vdp_idx <= 0;
+                    state   <= ST_LOAD_VDP0;
+                end else
+                    cpu_idx <= cpu_idx + 3'd1;
+            end
+        end
+
+        ST_LOAD_VDP0: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                case (vdp_idx[0])
+                    1'b0: begin vdp_regs_in[63:0]   <= DDRAM_DOUT; ddram_read(base_addr + 29'd7); end
+                    1'b1: begin vdp_regs_in[127:64]  <= DDRAM_DOUT; ddram_read(base_addr + 29'd8); end
+                endcase
+                if (vdp_idx[0]) begin
+                    cram_idx <= 0;
+                    state    <= ST_LOAD_CRAM;
+                end else
+                    vdp_idx[0] <= 1'b1;
+            end
+        end
+
+        ST_LOAD_CRAM: begin
+            // Read 6 DDRAM words, then restore 32 entries one-by-one
+            // Phase 1: read all 6 words (use cram_idx as word index)
+            // Phase 2: write entries (use cram_entry)
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                case (cram_idx)
+                    3'd0: begin cram_snap[63:0]    <= DDRAM_DOUT; ddram_read(base_addr + 29'd9);  end
+                    3'd1: begin cram_snap[127:64]  <= DDRAM_DOUT; ddram_read(base_addr + 29'd10); end
+                    3'd2: begin cram_snap[191:128] <= DDRAM_DOUT; ddram_read(base_addr + 29'd11); end
+                    3'd3: begin cram_snap[255:192] <= DDRAM_DOUT; ddram_read(base_addr + 29'd12); end
+                    3'd4: begin cram_snap[319:256] <= DDRAM_DOUT; ddram_read(base_addr + 29'd13); end
+                    3'd5: begin cram_snap[383:320] <= DDRAM_DOUT; ddram_read(base_addr + 29'd14); end
+                    default: ;
+                endcase
+                if (cram_idx == 5) begin
+                    // Start writing entries next cycle
+                    cram_entry <= 0;
+                    state      <= ST_LOAD_PSG;
+                    // Note: cram restore happens in ST_LOAD_RESTORE after all reads
+                end else
+                    cram_idx <= cram_idx + 3'd1;
+            end
+        end
+
+        ST_LOAD_PSG: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                psg_snap <= DDRAM_DOUT[55:0];
+                ddram_read(base_addr + 29'd15);
+                state    <= ST_LOAD_MAPPER;
+            end
+        end
+
+        ST_LOAD_MAPPER: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected    <= 0;
+                mapper_snap      <= DDRAM_DOUT;
+                // Restore memory (VRAM/WRAM) BEFORE applying registers so the VDP never
+                // renders with new register settings against old VRAM content.
+                vram_load_addr   <= 0;
+                vram_byte_cnt    <= 0;
+                vram_load_active <= 0;
+                word_cnt         <= 0;
+                ddram_read(base_addr + 29'h101);
+                state <= ST_LOAD_VRAM;
+            end
+        end
+
+        ST_LOAD_VRAM: begin
+            if (!vram_load_active) begin
+                // Wait for DDRAM read to complete, then latch the 64-bit word
+                if (DDRAM_DOUT_READY && dout_expected) begin
+                    dout_expected    <= 0;
+                    dout_latch       <= DDRAM_DOUT;
+                    vram_byte_cnt    <= 0;
+                    vram_load_active <= 1;
+                end
+            end else begin
+                // Write one byte per clock cycle from the latched word
+                vram_WE         <= 1;
+                vram_WA         <= vram_load_addr;
+                vram_WD         <= dout_latch[8*vram_byte_cnt +: 8];
+                vram_load_addr  <= vram_load_addr + 15'd1;
+                vram_byte_cnt   <= vram_byte_cnt + 3'd1; // 3-bit: wraps 7→0
+                if (vram_byte_cnt == 3'd7) begin
+                    // Last byte - deactivate and fetch next word
+                    vram_load_active <= 0;
+                    if (word_cnt < 11'd2047) begin
+                        word_cnt <= word_cnt + 11'd1;
+                        ddram_read(base_addr + 29'h101 + {18'd0, word_cnt + 11'd1});
+                    end else begin
+                        // VRAM done → WRAM
+                        wram_load_addr   <= 0;
+                        wram_byte_cnt    <= 0;
+                        wram_load_active <= 0;
+                        word_cnt         <= 0;
+                        ddram_read(base_addr + 29'h901);
+                        state <= ST_LOAD_WRAM;
+                    end
+                end
+            end
+        end
+
+        ST_LOAD_WRAM: begin
+            if (!wram_load_active) begin
+                if (DDRAM_DOUT_READY && dout_expected) begin
+                    dout_expected    <= 0;
+                    dout_latch       <= DDRAM_DOUT;
+                    wram_byte_cnt    <= 0;
+                    wram_load_active <= 1;
+                end
+            end else begin
+                wram_WE         <= 1;
+                wram_WA         <= wram_load_addr;
+                wram_WD         <= dout_latch[8*wram_byte_cnt +: 8];
+                wram_load_addr  <= wram_load_addr + 14'd1;
+                wram_byte_cnt   <= wram_byte_cnt + 3'd1;
+                if (wram_byte_cnt == 3'd7) begin
+                    wram_load_active <= 0;
+                    if (word_cnt < 11'd1023) begin
+                        word_cnt <= word_cnt + 11'd1;
+                        ddram_read(base_addr + 29'h901 + {18'd0, word_cnt + 11'd1});
+                    end else begin
+                        if (mapper_snap[48]) begin
+                            // Dahjee A: restore 8KB nvram
+                            nvram_load_addr   <= 0;
+                            nvram_byte_cnt    <= 0;
+                            nvram_load_active <= 0;
+                            word_cnt          <= 0;
+                            ddram_read(base_addr + 29'h0D01);
+                            state <= ST_LOAD_NVRAM;
+                        end else begin
+                            // All memory restored; restore mapper first, then core.
+                            state      <= ST_WAIT_RESTORE_BOUNDARY;
+                            cram_entry <= 0;
+                        end
+                    end
+                end
+            end
+        end
+
+        ST_LOAD_NVRAM: begin
+            if (!nvram_load_active) begin
+                if (DDRAM_DOUT_READY && dout_expected) begin
+                    dout_expected     <= 0;
+                    dout_latch        <= DDRAM_DOUT;
+                    nvram_byte_cnt    <= 0;
+                    nvram_load_active <= 1;
+                end
+            end else begin
+                nvram_WE        <= 1;
+                nvram_WA        <= nvram_load_addr;
+                nvram_WD        <= dout_latch[8*nvram_byte_cnt +: 8];
+                nvram_load_addr <= nvram_load_addr + 13'd1;
+                nvram_byte_cnt  <= nvram_byte_cnt + 3'd1;
+                if (nvram_byte_cnt == 3'd7) begin
+                    nvram_load_active <= 0;
+                    if (word_cnt < 11'd1023) begin
+                        word_cnt <= word_cnt + 11'd1;
+                        ddram_read(base_addr + 29'h0D01 + {18'd0, word_cnt + 11'd1});
+                    end else begin
+                        // All memory restored; restore mapper first, then core.
+                        state      <= ST_WAIT_RESTORE_BOUNDARY;
+                        cram_entry <= 0;
+                    end
+                end
+            end
+        end
+
+        ST_LOAD_RESTORE: begin
+            // VRAM/WRAM and mapper are fully restored. Apply CPU+VDP+PSG state,
+            // then stream CRAM while remaining frozen.
+            if (cram_entry == 0) begin
+                // CPU is frozen; restore all registers unconditionally.
+                // z80_set loads z80_dir into T80s regardless of CEN.
+                z80_set      <= 1;
+                vdp_regs_set <= 1;
+                psg_in       <= psg_snap;
+                psg_set      <= 1;
+            end
+            // Write CRAM entries one per cycle (32 cycles total)
+            cram_wr <= 1;
+            cram_A  <= cram_entry;
+            cram_D  <= cram_snap[12*cram_entry +: 12];
+            if (cram_entry == 31) begin
+                // All state applied; wait for VBlank before unfreezing
+                state <= ST_WAIT_VBLANK;
+            end else
+                cram_entry <= cram_entry + 5'd1;
+        end
+
+        // ---------------------------------------------------------------
+        ST_WAIT_VBLANK: begin
+            // Wait for a full VBlank rising → falling edge so we always unfreeze
+            // at y=0 (the very start of active display).  This guarantees:
+            //   • hbl_counter has been reloaded from irq_line_count by the VDP
+            //     during at least one VBlank line at x=486.
+            //   • The game resumes at the cleanest possible frame boundary.
+            // If we enter this state already inside VBlank (vblank=1), vblank_seen
+            // is set immediately, so we unfreeze on the next falling edge (y=0)
+            // rather than exiting right away mid-VBlank.
+            if (vblank)                   vblank_seen <= 1;
+            if (vblank_seen && !vblank)   state <= ST_UNFREEZE;
+        end
+
+        // ---------------------------------------------------------------
+        ST_UNFREEZE: begin
+            // Release freeze only on a quiet CE phase to avoid resuming exactly
+            // on a CPU/VDP enable pulse edge, which can cause rare load-time
+            // glitches or resets in timing-sensitive games.
+            if (!cpu_ce && !vdp_ce) begin
+                ss_freeze <= 0;
+                state     <= ST_IDLE;
+            end else begin
+                ss_freeze <= 1;
+            end
+        end
+        // ---------------------------------------------------------------
+        ST_ERROR: begin
+            // Handle load error - unfreeze and return to idle
+            ss_freeze <= 0;
+            state <= ST_IDLE;
+        end
+        default: state <= ST_IDLE;
+        endcase
+    end
+end
+
+endmodule

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -135,7 +135,37 @@ entity system is
 		ROMAD  : IN STD_LOGIC_VECTOR(24 downto 0);
 		ROMDT  : IN STD_LOGIC_VECTOR(7 downto 0);
 		ROMEN  : IN  STD_LOGIC;
-		BIOSWEN: IN  STD_LOGIC
+		BIOSWEN: IN  STD_LOGIC;
+
+		-- Save-state interface
+		z80_reg_out  : out STD_LOGIC_VECTOR(211 downto 0);
+		z80_dir      : in  STD_LOGIC_VECTOR(211 downto 0) := (others => '0');
+		z80_set      : in  STD_LOGIC := '0';
+		vdp_regs_out : out STD_LOGIC_VECTOR(127 downto 0);
+		vdp_regs_in  : in  STD_LOGIC_VECTOR(127 downto 0) := (others => '0');
+		vdp_regs_set : in  STD_LOGIC := '0';
+		vdp_cram_out : out STD_LOGIC_VECTOR(383 downto 0);
+		ss_cram_wr   : in  STD_LOGIC := '0';
+		ss_cram_A    : in  STD_LOGIC_VECTOR(4 downto 0)  := (others => '0');
+		ss_cram_D    : in  STD_LOGIC_VECTOR(11 downto 0) := (others => '0');
+		ss_vram_en   : in  STD_LOGIC := '0';
+		ss_vram_A    : in  STD_LOGIC_VECTOR(14 downto 0) := (others => '0');
+		ss_vram_D    : out STD_LOGIC_VECTOR(7 downto 0);
+		ss_vram_WE   : in  STD_LOGIC := '0';
+		ss_vram_WA   : in  STD_LOGIC_VECTOR(14 downto 0) := (others => '0');
+		ss_vram_WD   : in  STD_LOGIC_VECTOR(7 downto 0)  := (others => '0');
+		psg_out      : out STD_LOGIC_VECTOR(55 downto 0);
+		psg_in       : in  STD_LOGIC_VECTOR(55 downto 0) := (others => '0');
+		psg_set      : in  STD_LOGIC := '0';
+		mapper_out   : out STD_LOGIC_VECTOR(63 downto 0);
+		mapper_in    : in  STD_LOGIC_VECTOR(63 downto 0) := (others => '0');
+		mapper_set   : in  STD_LOGIC := '0';
+		-- Z80 instruction boundary detection (M1 cycle = opcode fetch)
+		z80_m1_n     : out STD_LOGIC;
+		-- MREQ_n: low = normal opcode fetch, high = interrupt acknowledge
+		z80_mreq_n   : out STD_LOGIC;
+		-- ISet: "00" = no prefix active (clean instruction boundary)
+		z80_iset     : out STD_LOGIC_VECTOR(1 downto 0)
 	);
 end system;
 
@@ -147,6 +177,7 @@ architecture Behavioral of system is
 	signal IORQ_n:				std_logic;
 	signal M1_n:				std_logic;
 	signal MREQ_n:				std_logic;
+	signal z80_iset_int:		std_logic_vector(1 downto 0);
 	signal A:					std_logic_vector(15 downto 0);
 	signal D_in:				std_logic_vector(7 downto 0);
 	signal D_out:				std_logic_vector(7 downto 0);
@@ -435,7 +466,11 @@ begin
 		WR_n		=> WR_n,
 		A			=> A,
 		DI			=> GENIE_DI,
-		DO			=> D_in
+		DO			=> D_in,
+		REG    => z80_reg_out,
+		DIRSet => z80_set,
+		DIR    => z80_dir,
+		ISet_out => z80_iset_int
 	);
 
 	vdp_inst: entity work.vdp
@@ -473,7 +508,20 @@ begin
 		ysj_quirk	=> ysj_quirk,
 		mask_column => mask_column,
 		black_column => black_column,
-		reset_n  => RESET_n
+		reset_n  => RESET_n,
+		ss_regs_out => vdp_regs_out,
+		ss_regs_in  => vdp_regs_in,
+		ss_regs_set => vdp_regs_set,
+		ss_cram_out => vdp_cram_out,
+		ss_cram_wr  => ss_cram_wr,
+		ss_cram_A   => ss_cram_A,
+		ss_cram_D   => ss_cram_D,
+		ss_vram_en  => ss_vram_en,
+		ss_vram_A   => ss_vram_A,
+		ss_vram_D   => ss_vram_D,
+		ss_vram_WE  => ss_vram_WE,
+		ss_vram_WA  => ss_vram_WA,
+		ss_vram_WD  => ss_vram_WD
 	);
 
 	vdp2_inst: entity work.vdp
@@ -526,7 +574,10 @@ begin
 		soundL	=> PSG_outL,
 		soundR	=> PSG_outR,
 
-		rst		=> not RESET_n
+		rst		=> not RESET_n,
+		ss_out => psg_out,
+		ss_set => psg_set,
+		ss_in  => psg_in
 	);
 	
 	psg2_inst: jt89
@@ -679,6 +730,9 @@ port map(
 	
 	ce_z80 <= ce_pix when (systeme = '1' or turbo='1') else ce_cpu;
 	io_cycle <= '1' when IORQ_n='0' and M1_n='1' else '0';
+	z80_m1_n   <= M1_n;
+	z80_mreq_n <= MREQ_n;
+	z80_iset   <= z80_iset_int;
 	io_upper_port <= '1' when A(7 downto 6)="11" else '0';
 	io_sms_port <= '1' when A(7 downto 6)="00" and (A(0)='1' or (gg='1' and A(5 downto 3)="000")) else '0';
 	io_gg_port <= '1' when gg='1' and A(7 downto 3)="00000" and A(2 downto 1)/="11" else '0';
@@ -826,6 +880,12 @@ port map(
 		if rising_edge(clk_sys) then
 			if RESET_n='0' then 
 				bootloader_n <= not bios_en;
+			elsif mapper_set='1' then
+				-- Save-state restore: recover exact bootloader_n captured at save time.
+				-- Without this, restoring a cart game saved while BIOS was active but
+				-- disabled (bootloader_n=1) would leave bootloader_n=0 (reset default)
+				-- so the Z80 would read BIOS ROM instead of cart ROM → instant crash.
+				bootloader_n <= mapper_in(54);
 			elsif ctl_WR_n='0' then
 				if ext_bios_sel='1' and ext_bios_loaded='1' then
 					-- For external BIOS: honour port $3E bit 3 (active low BIOS enable)
@@ -980,6 +1040,24 @@ port map(
 
 		else
 			if rising_edge(clk_sys) then
+				if mapper_set = '1' then
+					bank0              <= mapper_in(7 downto 0);
+					bank1              <= mapper_in(15 downto 8);
+					bank2              <= mapper_in(23 downto 16);
+					bank3              <= mapper_in(31 downto 24);
+					pak4_reg0          <= mapper_in(7 downto 0);
+					pak4_reg2          <= mapper_in(39 downto 32);
+					nem_bank0          <= mapper_in(47 downto 40);
+					nvram_e            <= mapper_in(50);
+					nvram_ex           <= mapper_in(51);
+					nvram_p            <= mapper_in(52);
+					nvram_cme          <= mapper_in(53);
+					mapper_zemina_det  <= mapper_in(56);
+					mapper_4pak        <= mapper_in(57);
+					mapper_codies      <= mapper_in(58);
+					lock_mapper_B      <= mapper_in(59);
+					mapper_codies_lock <= mapper_in(60);
+				else
 				if bootloader_n = '0' and mapper_manual_force = '0' then
 					lock_mapper_B <= '0';
 					mapper_codies <= '0';
@@ -1174,6 +1252,7 @@ port map(
 						end case ;
 					end if;
 				end if;
+				end if; -- mapper_set
 			end if;
 		end if;
 	end process;
@@ -1248,6 +1327,18 @@ port map(
 	                            ((rom_page0_byte0 = x"FF" and rom_page0_byte1 = x"FF" and rom_last_byte0 /= x"FF") or
 								 (rom_page0_byte0 = x"00" and rom_page0_byte1 = x"00" and rom_last_byte0 = x"F3")) else
 	                      '0';
+
+	-- Save-state: pack all mapper state into one 64-bit word.
+	-- [63]detect_linear [62]detect_wonderkid [61]detect_castle [60]mapper_codies_lock
+	-- [59]lock_mapper_B [58]mapper_codies [57]mapper_4pak [56]mapper_zemina_det
+	-- [55]spare [54]bootloader_n [53]nvram_cme [52]nvram_p [51]nvram_ex [50]nvram_e
+	-- [49]detect_sega_locked [48]detect_dahjee_a [47:40]nem_bank0 [39:32]pak4_reg2
+	-- [31:24]bank3 [23:16]bank2 [15:8]bank1 [7:0]bank0
+	mapper_out <= detect_linear & detect_wonderkid & detect_castle & mapper_codies_lock &
+	              lock_mapper_B & mapper_codies & mapper_4pak & mapper_zemina_det &
+	              '0' & bootloader_n & nvram_cme & nvram_p & nvram_ex & nvram_e &
+	              detect_sega_locked & detect_dahjee_a &
+	              nem_bank0 & pak4_reg2 & bank3 & bank2 & bank1 & bank0;
 
 	-- Nemesis I/II split is heuristic-only.
 	-- detect_nemesis1: Zemina writes + page0 appears blank while last page has code.
@@ -1359,6 +1450,12 @@ port map(
 				wonderkid_write_seen <= '0';
 				wonderkid_write_count <= 0;
 				sega_mapper_write_seen <= '0';
+			elsif mapper_set = '1' then
+				detect_castle      <= mapper_in(61);
+				detect_wonderkid   <= mapper_in(62);
+				detect_linear      <= mapper_in(63);
+				detect_dahjee_a    <= mapper_in(48);
+				detect_sega_locked <= mapper_in(49);
 			else
 				if bootloader_n = '0' then
 					mapper_detect_ticks <= (others => '0');

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -305,10 +305,9 @@ architecture Behavioral of system is
 	-- Zemina:    8KB banking via writes to $0000-$0003; $0000-$1FFF starts from page 0.
 	-- Nemesis I: same as Zemina but $0000-$1FFF initially reads from the LAST 8KB page.
 	-- Nemesis II+/plain Zemina: $0000-$1FFF starts from page 0.
-	-- Heuristic split uses early Zemina writes plus ROM edge-byte signature.
-	signal mapper_zemina_det  : std_logic := '0';  -- auto-detected by write to $0002/$0003
+	-- Auto-detection is restricted to CRC/header signatures.
 	signal nem_bank0          : std_logic_vector(7 downto 0) := "00000000";  -- $0000-$1FFF bank
-	signal auto_nemesis1_boot : std_logic;
+	signal mapper_nemesis_auto: std_logic;  -- Nemesis I special boot page by CRC
 	signal use_zem            : std_logic;  -- active for any Zemina-family mapper
 	signal rom_size_pages     : std_logic_vector(7 downto 0)  := (others => '0');
 	-- CRC16-CCITT (poly 0x1021, init 0xFFFF) of last 8KB block, accumulated during ROM load.
@@ -316,12 +315,8 @@ architecture Behavioral of system is
 	-- bytes) but uses Codemasters-style banking -- the CRC is needed because the MSX detector
 	-- fires on the first two ROM reads, before any write-based heuristic can fire.
 	signal rom_crc16_run      : std_logic_vector(15 downto 0) := x"FFFF";
-	-- CRC-based identity for F-1 Spirit (Korea), which uses Zemina 8KB banking
-	-- but writes ONLY $0000 (the $8000-$9FFF bank register) and never $0001/$0002/$0003.
-	-- Write-based detection never fires for it, so CRC (of last 8KB block: 0x599E)
-	-- is the only reliable way to activate Zemina mode before the first $4000-$5FFF access.
-	-- Other Zemina games (Nemesis 2, Knightmare II, Penguin Adventure) write $0002/$0003
-	-- and are caught by the write-based heuristic; no CRC needed for them.
+	-- CRC-based plain-Zemina identities:
+	-- Nemesis II (0x9136), F-1 Spirit (0x599E), Knightmare II (0xC47B), Penguin Adventure (0x880E).
 	signal mapper_zemina_crc  : std_logic;
 
 	-- Heuristic detection signals
@@ -330,20 +325,14 @@ architecture Behavioral of system is
 	signal detect_linear       : std_logic := '0';
 	signal detect_wonderkid    : std_logic := '0';
 	signal detect_sega_locked  : std_logic := '0';
-	signal detect_4pak         : std_logic := '0';
-	signal detect_nemesis1     : std_logic := '0';
-	signal detect_nemesis2     : std_logic := '0';
-	signal wonderkid_write_seen: std_logic := '0';
 	signal wonderkid_write_count: integer range 0 to 3 := 0;
 	signal castle_write_count  : integer range 0 to 15 := 0;
 	signal bank_write_seen     : std_logic := '0';
 	signal sega_mapper_write_seen : std_logic := '0';
 	signal mapper_detect_ticks : unsigned(15 downto 0) := (others => '0'); -- detection window timer (16-bit: ~1.2ms at 53.6MHz, needed for external BIOS handoff)
-	-- Simple ROM-edge signature captured during download, used by Nemesis heuristics.
+	-- Simple page-0 signature captured during download, used by Wonder Kid heuristic guards.
 	signal rom_page0_byte0     : std_logic_vector(7 downto 0) := x"FF";
 	signal rom_page0_byte1     : std_logic_vector(7 downto 0) := x"FF";
-	signal rom_last_byte0      : std_logic_vector(7 downto 0) := x"FF";
-	signal rom_last_page_idx   : unsigned(7 downto 0) := (others => '0');
 	signal mapper_manual_force  : std_logic;
 	signal mapper_castle        : std_logic := '0'; -- The Castle (Japan): 32KB RAM at 0x8000-0xFFFF
 	signal mapper_wonderkid     : std_logic;         -- Wonder Kid [Proto]: Codemasters-style 16KB, all banks init 0
@@ -1032,7 +1021,6 @@ port map(
 			mapper_4pak <= '0' ;
 			pak4_reg0 <= "00000000" ;
 			pak4_reg2 <= "00000000" ;
-			mapper_zemina_det <= '0' ;
 			nem_bank0 <= (others => '0');
 			mapper_wonderkid_prev <= '0';
 			reset_n_prev <= '0';
@@ -1052,7 +1040,6 @@ port map(
 					nvram_ex           <= mapper_in(51);
 					nvram_p            <= mapper_in(52);
 					nvram_cme          <= mapper_in(53);
-					mapper_zemina_det  <= mapper_in(56);
 					mapper_4pak        <= mapper_in(57);
 					mapper_codies      <= mapper_in(58);
 					lock_mapper_B      <= mapper_in(59);
@@ -1062,7 +1049,6 @@ port map(
 					lock_mapper_B <= '0';
 					mapper_codies <= '0';
 					mapper_codies_lock <= '0';
-					mapper_zemina_det <= '0';
 				end if;
 				-- BIOS handoff: restore standard cartridge startup banks.
 				-- BIOS bank writes can leave bank0/1/2 in non-default states, which
@@ -1083,19 +1069,18 @@ port map(
 					end if;
 				end if;
 				-- On the first clock after RESET_n rises, initialise mapper state.
-				-- rom_size_pages / rom_page0_byte0 / rom_last_byte0 are stable here because
+				-- rom_size_pages is stable here because
 				-- cart_download holds RESET_n low throughout the entire ROM transfer.
 				if RESET_n = '1' and reset_n_prev = '0' then
 					if mapper_zemina_force = '1' then
 						nem_bank0 <= (others => '0');
-					elsif auto_nemesis1_boot = '1' then
-						-- ROM page 0 is blank (all $FF) but the last page carries code
-						-- → strong Nemesis I signature. Pre-activate the Zemina mapper
-						-- and point nem_bank0 at the last page so the CPU's first fetch
-						-- ($0000) reaches the game's actual entry code instead of $FF.
-						mapper_zemina_det <= '1';
-						nem_bank0 <= std_logic_vector(rom_last_page_idx);
-					elsif mapper_wonderkid = '1' then
+					elsif mapper_nemesis_auto = '1' and unsigned(rom_size_pages) /= 0 then
+						-- Nemesis I needs $0000-$1FFF mapped to the last 8KB page on boot.
+						nem_bank0 <= std_logic_vector(unsigned(rom_size_pages) - 1);
+					else
+						nem_bank0 <= (others => '0');
+					end if;
+					if mapper_wonderkid = '1' then
 						-- All slots start at page 0; pre-lock to prevent 4-PAK misdetection
 						bank1         <= "00000000";
 						bank2         <= "00000000";
@@ -1166,29 +1151,8 @@ port map(
 						("00" & unsigned(D_in(5 downto 4)) & "0000") +
 						to_unsigned(0, 8)); -- reg2=0 initially
 				else
-					-- Zemina auto-detection: writes to $0001-$0003 indicate 8KB banking.
-					-- $0000 is deliberately excluded: Codemasters games write to $0000
-					-- (their bank0 register) before writing $4000/$8000, so a $0000 write
-					-- with lock_mapper_B='0' is ambiguous. Detection via $0001/$0002/$0003
-					-- is sufficient -- real Zemina games always bank-switch those slots.
-					-- Once Zemina is confirmed, subsequent $0000 writes update bank2.
-					if WR_n='0' and MREQ_n='0' and bootloader_n='1' and lock_mapper_B='0' then
-						if A = x"0000" then
-							-- Don't trigger detection here; only update bank2 if already confirmed.
-							if mapper_zemina_det = '1' then
-								bank2 <= D_in;
-							end if;
-						elsif A = x"0001" then
-							mapper_zemina_det <= '1';
-							bank3 <= D_in;
-						elsif A = x"0002" then
-							mapper_zemina_det <= '1';
-							bank0 <= D_in;
-						elsif A = x"0003" then
-							mapper_zemina_det <= '1';
-							bank1 <= D_in;
-						end if;
-					end if;
+					-- No write-triggered Zemina detection here.
+					-- Zemina mode is selected by header/CRC/OSD; once active, writes are handled in the use_zem branch above.
 					if WR_n='0' and A(15 downto 2)="11111111111111" then
 						-- A write to $FFFC-$FFFF is a Sega mapper register; disable Codemasters
 						-- detection unless it was already confirmed (mapper_codies_lock='1') or forced.
@@ -1275,14 +1239,18 @@ port map(
 	-- fallback for ROM dumps where the CRC differs.
 	-- CRC16-CCITT of last 8KB block: 0x8613
 
-	-- F-1 Spirit (Korea) is a plain-Zemina game that must be activated by CRC
-	-- because it only writes $0000 and never $0001/$0002/$0003. Its startup
-	-- code accesses $4000-$5FFF before any write-based heuristic can fire, so
-	-- Zemina 8KB banking must be selected from the first CPU clock to avoid
-	-- incorrect Sega-mode banking. Other Zemina-family games remain detected by
-	-- write-based heuristics when possible; CRC is used only for this known case.
+	-- Nemesis I requires a special startup mapping: $0000-$1FFF from the last page.
+	mapper_nemesis_auto <= '1' when mapper_manual_force = '0' and
+	                                rom_crc16_run = x"EE05" else
+	                       '0';
+
+	-- Plain Zemina CRCs (page-0 boot):
+	-- 9136 Nemesis II, 599E F-1 Spirit, C47B Knightmare II, 880E Penguin Adventure.
 	mapper_zemina_crc <= '1' when mapper_manual_force = '0' and
-	                              rom_crc16_run = x"599E" else  -- F-1 Spirit (Korea): writes only $0000
+	                              (rom_crc16_run = x"9136" or
+	                               rom_crc16_run = x"599E" or
+	                               rom_crc16_run = x"C47B" or
+	                               rom_crc16_run = x"880E") else
 	                     '0';
 
 	mapper_wonderkid <= '1' when mapper_manual_force = '0' and
@@ -1320,29 +1288,19 @@ port map(
 	                  '1' when mapper_manual_force = '0' and detect_dahjee_a = '1' else
 	                  '0';
 
-	-- 4-PAK auto-detection is now write-based only ($3FFE first-write pattern).
-	-- auto_nemesis1_boot: accept either the "FF/FF + last != FF" signature or
-	-- the Korea Nemesis signature observed in some dumps (page0 == 00/00 and last page first byte = 0xF3).
-	auto_nemesis1_boot <= '1' when mapper_manual_force = '0' and bank_write_seen = '0' and unsigned(rom_size_pages) >= 8 and
-	                            ((rom_page0_byte0 = x"FF" and rom_page0_byte1 = x"FF" and rom_last_byte0 /= x"FF") or
-								 (rom_page0_byte0 = x"00" and rom_page0_byte1 = x"00" and rom_last_byte0 = x"F3")) else
-	                      '0';
+	-- 4-PAK auto-detection is write-based only ($3FFE first-write pattern).
 
 	-- Save-state: pack all mapper state into one 64-bit word.
 	-- [63]detect_linear [62]detect_wonderkid [61]detect_castle [60]mapper_codies_lock
-	-- [59]lock_mapper_B [58]mapper_codies [57]mapper_4pak [56]mapper_zemina_det
+	-- [59]lock_mapper_B [58]mapper_codies [57]mapper_4pak [56]spare
 	-- [55]spare [54]bootloader_n [53]nvram_cme [52]nvram_p [51]nvram_ex [50]nvram_e
 	-- [49]detect_sega_locked [48]detect_dahjee_a [47:40]nem_bank0 [39:32]pak4_reg2
 	-- [31:24]bank3 [23:16]bank2 [15:8]bank1 [7:0]bank0
 	mapper_out <= detect_linear & detect_wonderkid & detect_castle & mapper_codies_lock &
-	              lock_mapper_B & mapper_codies & mapper_4pak & mapper_zemina_det &
+	              lock_mapper_B & mapper_codies & mapper_4pak & '0' &
 	              '0' & bootloader_n & nvram_cme & nvram_p & nvram_ex & nvram_e &
 	              detect_sega_locked & detect_dahjee_a &
 	              nem_bank0 & pak4_reg2 & bank3 & bank2 & bank1 & bank0;
-
-	-- Nemesis I/II split is heuristic-only.
-	-- detect_nemesis1: Zemina writes + page0 appears blank while last page has code.
-	-- detect_nemesis2: Zemina writes + no Nemesis I confidence.
 
 	-- Active for any Zemina-family mapper.
 	-- mapper_zemina_force (OSD): user explicitly selected Zemina mapper.
@@ -1350,13 +1308,11 @@ port map(
 	use_zem <= '1' when mapper_zemina_force = '1' else
 	           '0' when mapper_manual_force = '1' else
 	           '0' when mapper_wonderkid = '1' else  -- $8000 writes are incompatible with Zemina/MSX
-	           '1' when (mapper_msx = '1' or mapper_zemina_det = '1' or mapper_zemina_crc = '1' or
-	                    auto_nemesis1_boot = '1' or
-	                    detect_nemesis1 = '1' or detect_nemesis2 = '1') else
+	           '1' when (mapper_msx = '1' or mapper_nemesis_auto = '1' or mapper_zemina_crc = '1') else
 	           '0';
 
 	rom_a_i(12 downto 0) <= A(12 downto 0);
-	process (A,bank0,bank1,bank2,bank3,use_zem,nem_bank0,mapper_4pak,mapper_codies,systeme,sc3000_en,sc_multicart_en,sc_multicart_page,rom_bank,bootloader_n,mapper_linear,mapper_dahjee_a,auto_nemesis1_boot,rom_last_page_idx,detect_nemesis1)
+	process (A,bank0,bank1,bank2,bank3,use_zem,nem_bank0,mapper_4pak,mapper_codies,systeme,sc3000_en,sc_multicart_en,sc_multicart_page,rom_bank,bootloader_n,mapper_linear,mapper_dahjee_a)
 	begin
 		if systeme = '1' then
 			case A(15 downto 14) is
@@ -1379,12 +1335,8 @@ port map(
 		elsif use_zem = '1' and bootloader_n = '1' then
 			case A(15 downto 13) is
 			when "000" =>
-				-- $0000-$1FFF: fixed (Nemesis: last 8KB page; Zemina/MSX: page 0)
-				if detect_nemesis1 = '1' or auto_nemesis1_boot = '1' then
-					rom_a_i(21 downto 13) <= '0' & std_logic_vector(rom_last_page_idx);
-				else
-					rom_a_i(21 downto 13) <= '0' & nem_bank0;
-				end if;
+				-- $0000-$1FFF: fixed page (Nemesis I uses last page via nem_bank0).
+				rom_a_i(21 downto 13) <= '0' & nem_bank0;
 			when "001" =>
 				-- $2000-$3FFF: always page 1 (never remapped in Zemina/Nemesis)
 				rom_a_i(21 downto 13) <= "000000001";
@@ -1444,10 +1396,6 @@ port map(
 				detect_linear <= '0';
 				detect_wonderkid <= '0';
 				detect_sega_locked <= '0';
-				detect_4pak <= '0';
-				detect_nemesis1 <= '0';
-				detect_nemesis2 <= '0';
-				wonderkid_write_seen <= '0';
 				wonderkid_write_count <= 0;
 				sega_mapper_write_seen <= '0';
 			elsif mapper_set = '1' then
@@ -1466,10 +1414,6 @@ port map(
 					detect_linear <= '0';
 					detect_wonderkid <= '0';
 					detect_sega_locked <= '0';
-					detect_4pak <= '0';
-					detect_nemesis1 <= '0';
-					detect_nemesis2 <= '0';
-					wonderkid_write_seen <= '0';
 					wonderkid_write_count <= 0;
 					sega_mapper_write_seen <= '0';
 				-- run a limited detection window while bootloader is active
@@ -1479,28 +1423,14 @@ port map(
 
 				if bootloader_n = '1' and mapper_manual_force = '0' and mapper_detect_ticks < to_unsigned(65535, mapper_detect_ticks'length) then
 					if WR_n = '0' and MREQ_n = '0' then
-						-- 4-PAK register write pattern.
-						if A = x"3FFE" then
-							detect_4pak <= '1';
-						end if;
-
-						-- Wonder Kid [Proto]: keep the first $8000 write as a candidate,
-						-- then confirm it after the MSX header probe has finished.
-						if A = x"8000" and mapper_zemina_det = '0' and mapper_4pak = '0' and mapper_codies = '0' and detect_castle = '0' and detect_dahjee_a = '0' and sega_mapper_write_seen = '0' then
-							-- require two candidate writes to $8000 within detection window to avoid spurious single-write cases
+						-- Wonder Kid [Proto]: confirm after two $8000 writes during the detection window.
+						if A = x"8000" and mapper_4pak = '0' and mapper_codies = '0' and detect_castle = '0' and detect_dahjee_a = '0' and sega_mapper_write_seen = '0' then
 							if wonderkid_write_count < 2 then
 								wonderkid_write_count <= wonderkid_write_count + 1;
 							end if;
-							-- if previous count was 1, this is the second write -> mark seen
 							if wonderkid_write_count = 1 then
-								wonderkid_write_seen <= '1';
-								-- Immediately promote to detected if no stronger signatures present.
-								-- A write to $8000 is incompatible with the MSX/Zemina mapper
-								-- (which uses $0000-$0003), so mapper_msx is ignored here:
-								-- any ROM that writes to $8000 is definitely not MSX.
-								if mapper_manual_force = '0' and sega_mapper_write_seen = '0' and 
-								   rom_page0_byte0 = x"41" and rom_page0_byte1 = x"42" and
-								   mapper_zemina_det = '0' and detect_4pak = '0' and mapper_codies = '0' and detect_castle = '0' and detect_dahjee_a = '0' then
+								-- $8000 writes rule out MSX/Zemina register maps; require 0x41/0x42 header too.
+								if rom_page0_byte0 = x"41" and rom_page0_byte1 = x"42" then
 									detect_wonderkid <= '1';
 								end if;
 							end if;
@@ -1510,7 +1440,7 @@ port map(
 						-- Excludes common mapper registers to avoid false positives on Sega games.
 						if A(15 downto 14) = "10" and
 						   A /= x"8000" and A /= x"A000" and A /= x"BFFF" and A /= x"9FFF" and
-						   bank_write_seen = '0' and mapper_zemina_det = '0' and mapper_msx = '0' and mapper_4pak = '0' and mapper_codies = '0' then
+						   bank_write_seen = '0' and mapper_msx = '0' and mapper_4pak = '0' and mapper_codies = '0' then
 							if castle_write_count < 15 then
 								castle_write_count <= castle_write_count + 1;
 							end if;
@@ -1532,12 +1462,6 @@ port map(
 					end if;
 				end if;
 
-				if bootloader_n = '1' and mapper_manual_force = '0' and wonderkid_write_seen = '1' and sega_mapper_write_seen = '0' and 
-				   rom_page0_byte0 = x"41" and rom_page0_byte1 = x"42" and
-				   mapper_zemina_det = '0' and detect_4pak = '0' and mapper_codies = '0' and detect_castle = '0' and detect_dahjee_a = '0' then
-					detect_wonderkid <= '1';
-				end if;
-
 				-- Dahjee Type A: watch for writes to $2000-$3FFF at any point during boot.
 				-- $2000-$3FFF is ROM space; standard Sega games never write here.
 				-- $3FFE is the 4-PAK reg0 address and is explicitly excluded.
@@ -1549,15 +1473,6 @@ port map(
 
 				-- after detection window:
 				if mapper_manual_force = '0' and mapper_detect_ticks = to_unsigned(65534, mapper_detect_ticks'length) then
-					-- Nemesis split heuristic inside Zemina-family writes.
-					if mapper_zemina_det = '1' then
-						if rom_page0_byte0 = x"FF" and rom_page0_byte1 = x"FF" and rom_last_byte0 /= x"FF" then
-							detect_nemesis1 <= '1';
-						else
-							detect_nemesis2 <= '1';
-						end if;
-					end if;
-
 					-- 32KB pure-linear ROMs -> mapper_linear
 					if unsigned(rom_size_pages) = 4 and bank_write_seen = '0' then
 						detect_linear <= '1';
@@ -1577,8 +1492,7 @@ port map(
 
 	-- -----------------------------------------------------------------------
 	-- ROM metadata capture (runs on ROM download clock)
-	-- Tracks ROM size in 8KB pages and captures edge-byte signatures used
-	-- by Nemesis I/II heuristic split.
+	-- Tracks ROM size in 8KB pages and captures the page-0 signature bytes.
 	-- -----------------------------------------------------------------------
 	process (ROMCL)
 	begin
@@ -1587,10 +1501,8 @@ port map(
 				-- Reset page size counter on address 0 (start of new ROM)
 				if unsigned(ROMAD) = 0 then
 					rom_size_pages <= (others => '0');
-					rom_last_page_idx <= (others => '0');
 					rom_page0_byte0 <= x"FF";
 					rom_page0_byte1 <= x"FF";
-					rom_last_byte0 <= x"FF";
 				end if;
 
 				-- Update running CRC16-CCITT over the current (last-seen) 8KB block.
@@ -1601,14 +1513,10 @@ port map(
 				else
 					rom_crc16_run <= crc16_ccitt_byte(rom_crc16_run, ROMDT);
 				end if;
-				-- Capture first byte of page 0 and first byte of current highest page
+				-- Capture first bytes of ROM page 0.
 				if ROMAD(12 downto 0) = "0000000000000" then
 					if unsigned(ROMAD(20 downto 13)) = 0 then
 						rom_page0_byte0 <= ROMDT;
-					end if;
-					if unsigned(ROMAD(20 downto 13)) >= rom_last_page_idx then
-						rom_last_page_idx <= unsigned(ROMAD(20 downto 13));
-						rom_last_byte0 <= ROMDT;
 					end if;
 				end if;
 				if unsigned(ROMAD(20 downto 13)) = 0 and ROMAD(12 downto 0) = "0000000000001" then

--- a/rtl/vdp.vhd
+++ b/rtl/vdp.vhd
@@ -37,7 +37,74 @@ entity vdp is
 		smode_M3: 		out STD_LOGIC;
 		smode_M4: 		out STD_LOGIC;
 		ysj_quirk:		in  STD_LOGIC;
-		reset_n:       in  STD_LOGIC);
+		reset_n:       in  STD_LOGIC;
+
+		-- ----------------------------------------------------------------
+		-- Save-state interface
+		-- ----------------------------------------------------------------
+		-- Snapshot of VDP control registers (packed, combinational):
+		--  [0]            disable_hscroll
+		--  [1]            disable_vscroll
+		--  [2]            mask_column0
+		--  [3]            irq_line_en
+		--  [4]            spr_shift
+		--  [5]            mode_M4
+		--  [6]            mode_M2  (reg 0, bit 1)
+		--  [7]            display_on
+		--  [8]            irq_frame_en
+		--  [9]            mode_M1
+		--  [10]           mode_M3
+		--  [11]           spr_tall
+		--  [12]           spr_wide
+		--  [16:13]        bg_address
+		--  [19:17]        m2mg_address
+		--  [27:20]        m2ct_address
+		--  [35:28]        bg_scroll_x
+		--  [43:36]        bg_scroll_y
+		--  [50:44]        spr_address
+		--  [53:51]        spr_high_bits
+		--  [57:54]        legacy_fg_color
+		--  [61:58]        overscan
+		--  [69:62]        irq_line_count
+		--  [83:70]        xram_cpu_A
+		--  [84]           address_ff
+		--  [85]           to_cram
+		--  [93:86]        vram_cpu_D_outl  (read-latch)
+		--  [101:94]       cram_latch       (GG CRAM low-byte latch)
+		--  [102]          xram_cpu_read
+		--  [103]          reset_flags
+		--  [111:104]      hbl_counter
+		--  [114:112]      irq_delay
+		--  [115]          vbl_irq
+		--  [116]          hbl_irq
+		--  [117]          collide_flag
+		--  [118]          overflow_flag
+		--  [119]          line_overflow
+		--  [120]          last_x0
+		-- Total: 121 bits -> packed into ss_regs[127:0] (16 bytes, 2 DDRAM words)
+		ss_regs_out    : out STD_LOGIC_VECTOR(127 downto 0);
+		-- Restore: load all VDP control registers at once (held one cycle while ss_regs_set='1')
+		ss_regs_in     : in  STD_LOGIC_VECTOR(127 downto 0) := (others => '0');
+		ss_regs_set    : in  STD_LOGIC := '0';
+
+		-- CRAM snapshot (32 × 12 bits = 384 bits, combinational)
+		ss_cram_out    : out STD_LOGIC_VECTOR(383 downto 0);
+		-- CRAM restore: write one entry per cycle
+		ss_cram_wr     : in  STD_LOGIC := '0';
+		ss_cram_A      : in  STD_LOGIC_VECTOR(4 downto 0) := (others => '0');
+		ss_cram_D      : in  STD_LOGIC_VECTOR(11 downto 0) := (others => '0');
+
+		-- VRAM DMA read port (for save-state serialisation)
+		-- Present stable address on ss_vram_A for one clk_sys cycle; data is
+		-- available on ss_vram_D two cycles later (dpram latency).
+		ss_vram_en     : in  STD_LOGIC := '0';  -- '1' = port A belongs to DMA FSM
+		ss_vram_A      : in  STD_LOGIC_VECTOR(14 downto 0) := (others => '0');
+		ss_vram_D      : out STD_LOGIC_VECTOR(7 downto 0);
+		-- VRAM DMA write port (for restore)
+		ss_vram_WE     : in  STD_LOGIC := '0';
+		ss_vram_WA     : in  STD_LOGIC_VECTOR(14 downto 0) := (others => '0');
+		ss_vram_WD     : in  STD_LOGIC_VECTOR(7 downto 0) := (others => '0')
+	);
 end vdp;
 
 architecture Behavioral of vdp is
@@ -59,10 +126,16 @@ architecture Behavioral of vdp is
 	signal xram_cpu_A:		std_logic_vector(13 downto 0);
 	signal vram_cpu_WE:		std_logic;
 	signal cram_cpu_WE:		std_logic;
-	signal vram_cpu_D_out:	std_logic_vector(7 downto 0);	
+	signal vram_cpu_D_out:	std_logic_vector(7 downto 0);
+	signal vram_cpu_D_out_raw: std_logic_vector(7 downto 0);  -- raw port-A output (shared with SS DMA)
 	signal vram_cpu_D_outl:	std_logic_vector(7 downto 0);	
 	signal xram_cpu_A_incr:	std_logic := '0';
 	signal xram_cpu_read:	std_logic := '0';
+
+	-- internal muxed port-A signals for VRAM DPRAM
+	signal vram_portA_address : std_logic_vector(14 downto 0);
+	signal vram_portA_wren    : std_logic;
+	signal vram_portA_data    : std_logic_vector(7 downto 0);
 	
 	-- vram and cram lines for the video interface
 	signal vram_vdp_A:		std_logic_vector(13 downto 0);
@@ -176,7 +249,14 @@ begin
 		spr_overflow	=> spr_overflow);
 
     
-  vdp_vram_inst : entity work.dpram
+	-- combine/mux port-A signals for DPRAM
+	vram_portA_address <= ss_vram_WA when ss_vram_WE='1' else
+												ss_vram_A  when ss_vram_en='1' else
+												vram_cpu_A;
+	vram_portA_wren    <= ss_vram_WE or (vram_cpu_WE and not ss_vram_en);
+	vram_portA_data    <= ss_vram_WD when ss_vram_WE='1' else D_in;
+
+	vdp_vram_inst : entity work.dpram
     generic map
     (
       widthad_a		=> 15
@@ -184,10 +264,11 @@ begin
     port map
     (
       clock_a			=> clk_sys,
-      address_a		=> vram_cpu_A,
-      wren_a			=> vram_cpu_WE,
-      data_a			=> D_in,
-      q_a				=> vram_cpu_D_out,
+			-- During SS DMA the CPU is frozen; port A is driven by internal mux
+			address_a		=> vram_portA_address,
+			wren_a			=> vram_portA_wren,
+			data_a			=> vram_portA_data,
+      q_a				=> vram_cpu_D_out_raw,
 
       clock_b			=> clk_sys,
       address_b		=> se_bank & vram_vdp_A,
@@ -195,6 +276,10 @@ begin
       data_b			=> (others => '0'),
       q_b				=> vram_vdp_D
     );
+
+  -- Route port-A read data: during SS read DMA use it as ss_vram_D
+  ss_vram_D      <= vram_cpu_D_out_raw;
+  vram_cpu_D_out <= vram_cpu_D_out_raw;
 
 	vdp_cram_inst: entity work.vdp_cram
 	port map (
@@ -204,7 +289,11 @@ begin
 		cpu_D				=> cram_vdp_D_in,
 		vdp_clk			=> clk_sys,
 		vdp_A				=> cram_vdp_A,
-		vdp_D				=> cram_vdp_D
+		vdp_D				=> cram_vdp_D,
+		ss_D             => ss_cram_out,
+		ss_wr            => ss_cram_wr,
+		ss_A             => ss_cram_A,
+		ss_wD            => ss_cram_D
 	);
 
 	cram_vdp_A_in <= xram_cpu_A(4 downto 0) when gg='0' else xram_cpu_A(5 downto 1);
@@ -213,12 +302,55 @@ begin
 	cram_cpu_WE <= data_write when to_cram and ((gg='0') or (xram_cpu_A(0)='1')) and WR_direct='0' else '0';
 	vram_cpu_WE <= data_write when (WR_direct='1' or not to_cram) else '0';
 	vram_cpu_A <= not se_bank & A_direct & A when WR_direct='1' else se_bank & xram_cpu_A;
-	
+
+	-- ----------------------------------------------------------------
+	-- Save-state: VDP register snapshot (combinational)
+	-- ----------------------------------------------------------------
+	ss_regs_out(0)           	<= disable_hscroll;
+	ss_regs_out(1)           	<= disable_vscroll;
+	ss_regs_out(2)           	<= mask_column0;
+	ss_regs_out(3)           	<= irq_line_en;
+	ss_regs_out(4)           	<= spr_shift;
+	ss_regs_out(5)           	<= mode_M4;
+	ss_regs_out(6)           	<= mode_M2;
+	ss_regs_out(7)           	<= display_on;
+	ss_regs_out(8)           	<= irq_frame_en;
+	ss_regs_out(9)           	<= mode_M1;
+	ss_regs_out(10)          	<= mode_M3;
+	ss_regs_out(11)          	<= spr_tall;
+	ss_regs_out(12)          	<= spr_wide;
+	ss_regs_out(16 downto 13)	<= bg_address;
+	ss_regs_out(19 downto 17)	<= m2mg_address;
+	ss_regs_out(27 downto 20)	<= m2ct_address;
+	ss_regs_out(35 downto 28)	<= bg_scroll_x;
+	ss_regs_out(43 downto 36)	<= bg_scroll_y;
+	ss_regs_out(50 downto 44)	<= spr_address;
+	ss_regs_out(53 downto 51)	<= spr_high_bits;
+	ss_regs_out(57 downto 54)	<= legacy_fg_color;
+	ss_regs_out(61 downto 58)	<= overscan;
+	ss_regs_out(69 downto 62)	<= irq_line_count;
+	ss_regs_out(83 downto 70)	<= xram_cpu_A;
+	ss_regs_out(84)          	<= address_ff;
+	ss_regs_out(85)          	<= '1' when to_cram else '0';
+	ss_regs_out(93 downto 86) 	<= vram_cpu_D_outl;
+	ss_regs_out(101 downto 94)	<= cram_latch;
+	ss_regs_out(102)         	<= xram_cpu_read;
+	ss_regs_out(103)         	<= '1' when reset_flags else '0';
+	ss_regs_out(111 downto 104)	<= hbl_counter;
+	ss_regs_out(114 downto 112)	<= irq_delay;
+	ss_regs_out(115)         	<= vbl_irq;
+	ss_regs_out(116)         	<= hbl_irq;
+	ss_regs_out(117)         	<= collide_flag;
+	ss_regs_out(118)         	<= overflow_flag;
+	ss_regs_out(119)         	<= line_overflow;
+	ss_regs_out(120)         	<= last_x0;
+	ss_regs_out(127 downto 121)	<= (others => '0');
+
 	smode_M1 <= mode_M1 and mode_M2 ;
 	smode_M2 <= mode_M2;
 	smode_M3 <= mode_M3 and mode_M2 ;
 	smode_M4 <= mode_M4;
-	
+
 	process (clk_sys, reset_n)
 	variable reset_set: boolean ;
 	begin
@@ -251,6 +383,51 @@ begin
 		elsif rising_edge(clk_sys) then
 			data_write <= '0';
 			reset_set := false ;
+
+			-- Save-state register restore
+			if ss_regs_set = '1' then
+				disable_hscroll <= ss_regs_in(0);
+				disable_vscroll <= ss_regs_in(1);
+				mask_column0    <= ss_regs_in(2);
+				irq_line_en     <= ss_regs_in(3);
+				spr_shift       <= ss_regs_in(4);
+				mode_M4         <= ss_regs_in(5);
+				mode_M2         <= ss_regs_in(6);
+				display_on      <= ss_regs_in(7);
+				irq_frame_en    <= ss_regs_in(8);
+				mode_M1         <= ss_regs_in(9);
+				mode_M3         <= ss_regs_in(10);
+				spr_tall        <= ss_regs_in(11);
+				spr_wide        <= ss_regs_in(12);
+				bg_address      <= ss_regs_in(16 downto 13);
+				m2mg_address    <= ss_regs_in(19 downto 17);
+				m2ct_address    <= ss_regs_in(27 downto 20);
+				bg_scroll_x     <= ss_regs_in(35 downto 28);
+				bg_scroll_y     <= ss_regs_in(43 downto 36);
+				spr_address     <= ss_regs_in(50 downto 44);
+				spr_high_bits   <= ss_regs_in(53 downto 51);
+				legacy_fg_color <= ss_regs_in(57 downto 54);
+				overscan        <= ss_regs_in(61 downto 58);
+				irq_line_count  <= ss_regs_in(69 downto 62);
+				xram_cpu_A      <= ss_regs_in(83 downto 70);
+				address_ff      <= ss_regs_in(84);
+				to_cram         <= (ss_regs_in(85) = '1');
+				vram_cpu_D_outl <= ss_regs_in(93 downto 86);
+				cram_latch      <= ss_regs_in(101 downto 94);
+				xram_cpu_read   <= ss_regs_in(102);
+				-- reset_flags is a one-cycle side-effect of status-port reads.
+				-- Restoring it as '1' can clear freshly restored IRQ/status latches
+				-- on the first ce_vdp after unfreeze.
+				reset_flags     <= false;
+				-- Re-prime edge detectors to the live bus levels so the first
+				-- ce_vdp after unfreeze does not see a phantom RD/WR transition.
+				old_WR_n        <= WR_n;
+				old_RD_n        <= RD_n;
+				old_WR_direct   <= WR_direct;
+				old_HL          <= HL;
+				data_write      <= '0';
+				xram_cpu_A_incr <= '0';
+			end if;
 
 			old_HL <= HL;
 			if old_HL = '0' and HL = '1' then
@@ -366,7 +543,11 @@ begin
 	process (clk_sys)
 	begin
 		if rising_edge(clk_sys) then
-			if ce_vdp = '1' then
+			if ss_regs_set = '1' then
+				-- vbl_irq is transient; starting from asserted state can trigger
+				-- immediate post-restore interrupts on rapid consecutive loads.
+				vbl_irq <= '0';
+			elsif ce_vdp = '1' then
 --				485 instead of 487 to please VDPTEST 
 				if	x=485 and ((y=224 and xmode_M1='1') 
 					  or (y=240 and xmode_M3='1') 
@@ -383,7 +564,16 @@ begin
 	process (clk_sys)
 	begin
 		if rising_edge(clk_sys) then
-			if ce_vdp = '1' then
+			if ss_regs_set = '1' then
+				last_x0 <= ss_regs_in(120);
+				-- Restore hbl_counter to irq_line_count, not the mid-frame save-time value.
+				-- We always unfreeze at VBlank end (y=0), where hbl_counter must equal
+				-- irq_line_count (reloaded from it every VBlank by the normal logic).
+				-- Restoring the save-time countdown would cause the first post-restore
+				-- line IRQ to fire at the wrong scanline → garbled scroll effects.
+				hbl_counter <= ss_regs_in(69 downto 62); -- irq_line_count
+				hbl_irq <= '0';
+			elsif ce_vdp = '1' then
 				last_x0 <= std_logic(x(0));
 				if x=486 and not (last_x0=std_logic(x(0))) then
 					if y<192 or (y<240 and xmode_M3='1') or (y<224 and xmode_M1='1') or y=511 then
@@ -406,51 +596,58 @@ begin
 	process (clk_sys)
 	begin
 		if rising_edge(clk_sys) then
-		   -- using the other phase of ce_vdp permits to please VDPTEST ovr HCounter
-			-- very tight condition; 
-		   if ce_vdp = '0' then
-				if  (x<256 or x>485) and (y<234 or y>=496) then
-					if spr_overflow='1' and line_overflow='0' then
-						overflow_flag <= '1';
-						line_overflow <= '1';
-					end if ;
-				else	
-					line_overflow <= '0' ;
-				end if;
-			end if ;
-			
-			if ce_vdp = '1' then
-				xspr_collide_shift(13 downto 1) <= xspr_collide_shift(12 downto 0) ;
-				if (x<=256) then
-					xspr_collide_shift(0) <= spr_collide ;
-				else
-					xspr_collide_shift(0) <= '0' ;
-				end if;
-				if xspr_collide_shift(13)='1'  and 
-					display_on='1' and
-					(y<234 or (xmode_M1='0' and xmode_M3='0' and y>=496)) 
-				then
-					collide_flag <= '1' ;
-				end if;
-
-				if reset_flags then
-					collide_flag <= '0' ;
-					overflow_flag <= '0';
-					line_overflow <= '1'; -- Spr over many lines   
-				end if;
-
-				if ((vbl_irq='1' and irq_frame_en='1') or (hbl_irq='1' and irq_line_en='1'))
-					and not reset_flags then
-					if irq_delay = "000" then
-						IRQ_n <= '0';
+			if ss_regs_set = '1' then
+				irq_delay     <= "111";
+				collide_flag  <= ss_regs_in(117);
+				overflow_flag <= ss_regs_in(118);
+				line_overflow <= ss_regs_in(119);
+				IRQ_n         <= '1';
+			else
+				-- using the other phase of ce_vdp permits to please VDPTEST ovr HCounter
+				-- very tight condition;
+				if ce_vdp = '0' then
+					if (x<256 or x>485) and (y<234 or y>=496) then
+						if spr_overflow='1' and line_overflow='0' then
+							overflow_flag <= '1';
+							line_overflow <= '1';
+						end if;
 					else
-						irq_delay <= irq_delay - 1;
+						line_overflow <= '0';
 					end if;
-				else
-					IRQ_n <= '1';
-					irq_delay <= "111";
 				end if;
 
+				if ce_vdp = '1' then
+					xspr_collide_shift(13 downto 1) <= xspr_collide_shift(12 downto 0);
+					if (x<=256) then
+						xspr_collide_shift(0) <= spr_collide;
+					else
+						xspr_collide_shift(0) <= '0';
+					end if;
+					if xspr_collide_shift(13)='1' and
+						display_on='1' and
+						(y<234 or (xmode_M1='0' and xmode_M3='0' and y>=496))
+					then
+						collide_flag <= '1';
+					end if;
+
+					if reset_flags then
+						collide_flag <= '0';
+						overflow_flag <= '0';
+						line_overflow <= '1'; -- Spr over many lines
+					end if;
+
+					if ((vbl_irq='1' and irq_frame_en='1') or (hbl_irq='1' and irq_line_en='1'))
+						and not reset_flags then
+						if irq_delay = "000" then
+							IRQ_n <= '0';
+						else
+							irq_delay <= irq_delay - 1;
+						end if;
+					else
+						IRQ_n <= '1';
+						irq_delay <= "111";
+					end if;
+				end if;
 			end if;
 		end if;
 	end process;

--- a/rtl/vdp_cram.vhd
+++ b/rtl/vdp_cram.vhd
@@ -10,7 +10,14 @@ entity vdp_cram is
 		cpu_D:	in  STD_LOGIC_VECTOR (11 downto 0);
 		vdp_clk:	in  STD_LOGIC;
 		vdp_A:	in  STD_LOGIC_VECTOR (4 downto 0);
-		vdp_D:	out STD_LOGIC_VECTOR (11 downto 0));
+		vdp_D:	out STD_LOGIC_VECTOR (11 downto 0);
+		-- Save-state snapshot: all 32 entries read in one cycle (combinational)
+		ss_D:		out STD_LOGIC_VECTOR (11*32+31 downto 0);  -- 32 × 12 bits = 384 bits
+		-- Save-state restore: write one entry per cycle
+		ss_wr:	in  STD_LOGIC := '0';
+		ss_A:		in  STD_LOGIC_VECTOR (4 downto 0) := (others => '0');
+		ss_wD:	in  STD_LOGIC_VECTOR (11 downto 0) := (others => '0')
+	);
 end vdp_cram;
 
 architecture Behavioral of vdp_cram is
@@ -24,12 +31,20 @@ begin
 		variable i : integer range 0 to 31;
 	begin
 		if rising_edge(cpu_clk) then
-			if cpu_WE='1'then
+			if ss_wr = '1' then
+				i := to_integer(unsigned(ss_A));
+				ram(i) <= ss_wD;
+			elsif cpu_WE='1' then
 				i := to_integer(unsigned(cpu_A));
 				ram(i) <= cpu_D;
 			end if;
 		end if;
 	end process;
+
+	-- Snapshot: all 32 entries read combinationally for save-state DMA
+	gen_ss: for idx in 0 to 31 generate
+		ss_D(idx*12+11 downto idx*12) <= ram(idx);
+	end generate;
 
 	process (vdp_clk)
 		variable i : integer range 0 to 31;


### PR DESCRIPTION
This pull request introduces savestate support for the Sega Master System core. The main updates include the implementation of savestates, updates to the configuration string and OSD, wiring for savestate signals, and new assignments in the project configuration file.

**Savestate and BIOS Support:**

* Added savestate functionality, including persistent savestates for regular ROMs (saved to SD card) and volatile savestates for BIOS games (saved to memory only). The README and OSD are updated to document and expose these features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38) [[3]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL263-R300) [[4]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL329-R379)

**Configuration and OSD Improvements:**

* Extended the `CONF_STR` parameter in `SMS.sv` to include savestate slot selection, save/load actions, and updated joystick mappings to support savestate operations. [[1]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL263-R300) [[2]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL279-R313) [[3]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL329-R379)

* Updated the OSD and status handling logic to reflect savestate slot changes and new actions.

**Signal and Wiring Changes:**

* Added and wired numerous signals for savestate control, including DDRAM, VDP, PSG, mapper, WRAM, and NVRAM connections. This includes freezing the system during savestate operations and routing relevant data. [[1]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eR890-R951) [[2]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eR964-R977) [[3]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL193-R194)

**Project Configuration Updates:**

* Added new assignments to `SMS.qsf` for device family, pin locations, and included source files required for savestate.

**Minor Fixes and Cleanups:**

* Made minor code cleanups, such as replacing hardcoded values with explicit assignments and fixing configuration parameter names. [[1]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL211-R212) [[2]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eL279-R313)

These changes collectively introduce savestate support, while updating the user interface and wiring to support this new feature.