### PR TITLE
SaveStates and Pause for System-E, enhanced SaveStates for SMS

### DIFF
--- a/SMS.qsf
+++ b/SMS.qsf
@@ -13,7 +13,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
 set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Lite Edition"
 
 set_global_assignment -name GENERATE_RBF_FILE ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files

--- a/SMS.sv
+++ b/SMS.sv
@@ -39,8 +39,55 @@ assign BUTTONS   = osd_btn;
 assign VGA_SCALER= 0;
 assign VGA_DISABLE = 0;
 wire ss_freeze;
-assign HDMI_FREEZE = ss_freeze;
+reg  ss_freeze_r;
+always @(posedge clk_sys) begin
+	ss_freeze_r <= ss_freeze;
+end
+reg  [4:0] clkd;
+wire ss_unfreeze = ss_freeze_r & ~ss_freeze;
+// System E toggle-pause: joy[8] = Pause button (position 5 in J1 layout)
+wire       joy8_sig = swap ? joy_1[8] : joy_0[8];
+reg        joy8_r;
+reg        se_paused;
+reg        se_pause_pending;    // waiting for VBlank fall (y=0) to freeze CPU
+reg        se_unpause_pending;  // waiting for VBlank rising edge to release CPU
+reg        VBlank_r;            // one-cycle delay for VBlank edge detection
+wire       se_pause_gate = systeme & se_paused;
+assign HDMI_FREEZE   = 1'b0;
 assign HDMI_BLACKOUT = 0;
+
+always @(posedge clk_sys) begin
+	joy8_r   <= joy8_sig;
+	VBlank_r <= VBlank;
+	if (raw_reset | ~systeme | ss_freeze | ss_unfreeze) begin
+		se_paused          <= 0;
+		se_pause_pending   <= 0;
+		se_unpause_pending <= 0;
+	end else begin
+		// Rising edge of pause button (not during savestates, not already pending)
+		if (~joy8_r & joy8_sig & ~ss_freeze & ~se_unpause_pending & ~se_pause_pending) begin
+			if (se_paused)
+				// Defer CPU release to the next VBlank rising edge so the game's
+				// VBlank handler always runs *during* VBlank, not active display.
+				se_unpause_pending <= 1;
+			else
+				// Defer CPU freeze to the next VBlank fall (y=0) so the game's
+				// VBlank handler always completes before freezing; prevents
+				// tile/sprite corruption from a partially-updated VDP state.
+				se_pause_pending <= 1;
+		end
+		// VBlank fall (y=0): apply the deferred pause
+		if (se_pause_pending & VBlank_r & ~VBlank) begin
+			se_paused        <= 1;
+			se_pause_pending <= 0;
+		end
+		// VBlank rising edge: release the deferred unpause
+		if (se_unpause_pending & ~VBlank_r & VBlank) begin
+			se_paused          <= 0;
+			se_unpause_pending <= 0;
+		end
+	end
+end
 assign HDMI_BOB_DEINT = 0;
 assign FB_FORCE_BLANK = 0;
 
@@ -138,16 +185,16 @@ video_freak video_freak
 
 `include "build_id.v"
 parameter CONF_STR = {
-	"SMS;SS3E000000:10000;",
+	"SMS;SS3E000000:18000;",
 	"-;",
 	"H8FS1,SMSSG SC ;",
 	"H8FS2,GG;",
 	"-;",
-	"H8O[16:15],SaveState Slot,1,2,3,4;",
-	"H8R[61],Save State (Alt+F1);",
-	"H8R[62],Load State (F1);",
-	"DIP;",
+	"O[16:15],SaveState Slot,1,2,3,4;",
+	"R[61],Save State (Alt+F1);",
+	"R[62],Load State (F1);",
 	"-;",
+	"DIP;",
 	"C,Cheats;",
 	"H1OO,Cheats Enabled,ON,OFF;",
 	"-;",
@@ -208,11 +255,11 @@ parameter CONF_STR = {
 	"H8RB,Soft Reset;",
 	"H8R9,Eject ROM;",
 	"R0,Reset;",
-	"J1,Fire 1,Fire 2,Pause,Coin,Arcade 3,Soft Reset,-,-,SaveState;",
+	"J1,Fire 1,Fire 2,Pause,-,-,Soft Reset,-,-,SaveState;",
 	"jn,A|P,B,Start,Coin,X,Select;",
 	"jp,Y|P,A,Start,Coin,X,Select;",
 	"I,",
-	"Slot=DPAD|Save/Load=Pause+DPAD,",
+	"Slot=DPAD L/R|Save=Down|Load=Up,",
 	"Active Slot 1,",
 	"Active Slot 2,",
 	"Active Slot 3,",
@@ -452,6 +499,18 @@ wire code_index = &ioctl_index;
 wire code_download = ioctl_download & code_index;
 wire bios_download = ioctl_download & (ioctl_index[4:0] == 3);
 wire cart_download = ioctl_download & ~code_index & (ioctl_index[4:0]!=3) & (ioctl_index!=4) & (ioctl_index!=254);
+
+// Rolling signature of the currently loaded ROM image.
+// Used by savestates header validation to reject cross-ROM loads.
+reg [31:0] ss_game_id = 32'h00000000;
+reg        cart_download_r = 1'b0;
+always @(posedge clk_sys) begin
+	cart_download_r <= cart_download;
+	if (~cart_download_r & cart_download)
+		ss_game_id <= 32'h811C9DC5;
+	else if (ioctl_wr & cart_download)
+		ss_game_id <= {ss_game_id[30:0], ss_game_id[31]} ^ {24'd0, ioctl_dout} ^ {7'd0, ioctl_addr[0], ioctl_addr[8], ioctl_addr[16]};
+end
 
 // BIOS mode: status[44:43] == 2'b00->Disable, 01->Internal, 10->Ext. File
 wire bios_en      = (status[44:43] != 2'b00) & ~systeme;
@@ -755,7 +814,7 @@ wire [63:0] ss_ddram_din;
 wire [7:0]  ss_ddram_be;
 wire        ss_ddram_we;
 wire        ss_ddram_rd;
-wire [211:0] ss_z80_reg, ss_z80_dir;
+wire [229:0] ss_z80_reg, ss_z80_dir;
 wire         ss_z80_set;
 wire         ss_z80_m1_n;
 wire         ss_z80_mreq_n;   // low = normal opcode fetch, high = interrupt ack
@@ -774,6 +833,47 @@ wire [55:0]  ss_psg_out, ss_psg_in;
 wire         ss_psg_set;
 wire [63:0]  ss_mapper_out, ss_mapper_in;
 wire         ss_mapper_set;
+wire [31:0]  ss_io_out, ss_io_in;
+wire         ss_io_set;
+reg [1:0] restored_vdp_enables;
+reg [1:0] restored_psg_enables;
+reg       has_restored_enables = 0;
+reg [1:0] last_status_vdp_enables;
+reg [1:0] last_status_psg_enables;
+
+always @(posedge clk_sys) begin
+	last_status_vdp_enables <= status[34:33];
+	last_status_psg_enables <= status[36:35];
+
+	if (raw_reset) begin
+		has_restored_enables <= 1'b0;
+	end else begin
+		if (ss_io_set) begin
+			restored_vdp_enables <= ss_io_in[28:27];
+			restored_psg_enables <= ss_io_in[30:29];
+			has_restored_enables <= 1'b1;
+		end else if (status[34:33] != last_status_vdp_enables || status[36:35] != last_status_psg_enables) begin
+			has_restored_enables <= 1'b0;
+		end
+	end
+end
+
+wire [21:0]  ss_video_state_out, ss_video_state_in;
+wire         ss_video_state_set;
+
+// System E VDP2 / PSG2 save-state wires
+wire [127:0] ss_vdp2_regs, ss_vdp2_regs_in;
+wire         ss_vdp2_regs_set;
+wire [383:0] ss_vdp2_cram;
+wire  [4:0]  ss_cram2_A;
+wire [11:0]  ss_cram2_D;
+wire         ss_cram2_wr;
+wire         ss_vram2_en;
+wire [14:0]  ss_vram2_A, ss_vram2_WA;
+wire  [7:0]  ss_vram2_D, ss_vram2_WD;
+wire         ss_vram2_WE;
+wire [55:0]  ss_psg2_out, ss_psg2_in;
+wire         ss_psg2_set;
 wire [13:0]  ss_wram_A, ss_wram_WA;
 wire  [7:0]  ss_wram_WD;
 wire         ss_wram_WE;
@@ -810,19 +910,20 @@ wire  [7:0] nvram_d;
 wire  [7:0] nvram_q;
 
 // NVRAM DMA wires (savestates → nvram_inst during ss_freeze)
-wire [12:0] ss_nvram_A;    // DMA read address
+wire [14:0] ss_nvram_A;    // DMA read address
 wire        ss_nvram_WE;   // DMA write enable
-wire [12:0] ss_nvram_WA;   // DMA write address
+wire [14:0] ss_nvram_WA;   // DMA write address
 wire  [7:0] ss_nvram_WD;   // DMA write data
 // nvram_q feeds ss_nvram_D directly (read data back to savestates)
 
 system #(63) system
 (
 	.clk_sys(clk_sys),
-	.ce_cpu(ce_cpu & ~ss_freeze),
-	.ce_vdp(ce_vdp & ~ss_freeze),
-	.ce_pix(ce_pix & ~ss_freeze),
-	.ce_sp(ce_sp  & ~ss_freeze),
+	.ss_freeze(ss_freeze),
+	.ce_cpu(ss_freeze ? 1'b0 : (ce_cpu & ~se_pause_gate)),
+	.ce_vdp(ss_freeze ? 1'b0 : ce_vdp),
+	.ce_pix(ss_freeze ? 1'b0 : ce_pix),
+	.ce_sp(ss_freeze ? 1'b0 : ce_sp),
 	.turbo(turbo),
 	.gg(gg),
 	.ggres(ggres),
@@ -853,9 +954,9 @@ system #(63) system
 	.j1_tl(joya[4]),
 	.j1_tr(joya[5]),
 	.j1_th(joya_th),
-	.j1_start(swap ? joy_1[11] : joy_0[11]),
-	.j1_coin(swap ? joy_1[10] : joy_0[10]),
-	.j1_a3(swap ? joy_1[8] : joy_0[8]),
+	.j1_start(swap ? joy_1[6] : joy_0[6]),
+	.j1_coin(swap ? joy_1[7] : joy_0[7]),
+	.j1_a3(swap ? joy_1[6] : joy_0[6]),
 
 	.j2_up(joyb[3]),
 	.j2_down(joyb[2]),
@@ -864,11 +965,12 @@ system #(63) system
 	.j2_tl(joyb[4]),
 	.j2_tr(joyb[5]),
 	.j2_th(joyb_th),
-	.pause(joya[6]&joyb[6]),
+	.pause(systeme ? 1'b1 : (joya[6]&joyb[6])),
+	.se_pause(se_pause_gate),
 	.soft_reset(soft_reset_btn),
-	.j2_start(swap ? joy_0[11] : joy_1[11]),
-	.j2_coin(swap ? joy_0[10] : joy_1[10]),
-	.j2_a3(swap ? joy_0[8] : joy_1[8]),
+	.j2_start(swap ? joy_0[6] : joy_1[6]),
+	.j2_coin(swap ? joy_0[7] : joy_1[7]),
+	.j2_a3(swap ? joy_0[6] : joy_1[6]),
 
 	.j1_tr_out(joya_tr_out),
 	.j1_th_out(joya_th_out),
@@ -912,8 +1014,8 @@ system #(63) system
 	.mapper_dahjee_a_force(mapper_force_dahjee_a),
 	.mapper_linear_force(mapper_force_linear),
 	.mapper_zemina_force(mapper_force_zemina),
-	.vdp_enables(dbg_menu ? status[34:33] : 2'b00),
-	.psg_enables(dbg_menu ? status[36:35] : 2'b00),
+	.vdp_enables(has_restored_enables ? restored_vdp_enables : (dbg_menu ? status[34:33] : 2'b00)),
+	.psg_enables(has_restored_enables ? restored_psg_enables : (dbg_menu ? status[36:35] : 2'b00)),
 
 	.fm_ena(~status[12] | gg),
 	.audioL(audio_l),
@@ -966,7 +1068,27 @@ system #(63) system
 	.mapper_set  (ss_mapper_set),
 	.z80_m1_n    (ss_z80_m1_n),
 	.z80_mreq_n  (ss_z80_mreq_n),
-	.z80_iset    (ss_z80_iset)
+	.z80_iset    (ss_z80_iset),
+	// System E VDP2 / PSG2 save-state
+	.vdp2_regs_out(ss_vdp2_regs),
+	.vdp2_regs_in (ss_vdp2_regs_in),
+	.vdp2_regs_set(ss_vdp2_regs_set),
+	.vdp2_cram_out(ss_vdp2_cram),
+	.ss_cram2_wr  (ss_cram2_wr),
+	.ss_cram2_A   (ss_cram2_A),
+	.ss_cram2_D   (ss_cram2_D),
+	.ss_vram2_en  (ss_vram2_en),
+	.ss_vram2_A   (ss_vram2_A),
+	.ss_vram2_D   (ss_vram2_D),
+	.ss_vram2_WE  (ss_vram2_WE),
+	.ss_vram2_WA  (ss_vram2_WA),
+	.ss_vram2_WD  (ss_vram2_WD),
+	.psg2_out     (ss_psg2_out),
+	.psg2_in      (ss_psg2_in),
+	.psg2_set     (ss_psg2_set),
+	.io_state_out (ss_io_out),
+	.io_state_in  (ss_io_in),
+	.io_state_set (ss_io_set)
 );
 
 savestate_ui savestate_ui_inst (
@@ -990,6 +1112,8 @@ savestate_ui savestate_ui_inst (
 	.statusUpdate(ss_status)
 );
 
+wire clkref_cpu = (systeme | turbo) ? ce_pix : ce_cpu;
+
 savestates savestates_inst (
 	.clk             (clk_sys),
 	.reset_n         (~reset_active),
@@ -997,8 +1121,10 @@ savestates savestates_inst (
 	.ss_load         (ss_load),
 	.ss_slot         (ss_slot),
 	.ss_bios_mode    (ss_bios_mode),
+	.ss_game_id      (ss_game_id),
 	.ss_freeze       (ss_freeze),
 	.vblank          (VBlank),
+	.x               (x),
 	// Z80
 	.z80_reg         (ss_z80_reg),
 	.z80_dir         (ss_z80_dir),
@@ -1006,8 +1132,10 @@ savestates savestates_inst (
 	.z80_m1_n        (ss_z80_m1_n),
 	.z80_mreq_n      (ss_z80_mreq_n),
 	.z80_iset        (ss_z80_iset),
-	.cpu_ce          (ce_cpu),
+	.cpu_ce          (clkref_cpu),
 	.vdp_ce          (ce_vdp),
+	.pix_ce          (ce_pix),
+	.sp_ce           (ce_sp),
 	// VDP registers
 	.vdp_regs        (ss_vdp_regs),
 	.vdp_regs_in     (ss_vdp_regs_in),
@@ -1032,6 +1160,12 @@ savestates savestates_inst (
 	.mapper_out      (ss_mapper_out),
 	.mapper_in       (ss_mapper_in),
 	.mapper_set      (ss_mapper_set),
+	.io_out          (ss_io_out),
+	.io_in           (ss_io_in),
+	.io_set          (ss_io_set),
+	.video_state_out (ss_video_state_out),
+	.video_state_in  (ss_video_state_in),
+	.video_state_set (ss_video_state_set),
 	// WRAM DMA
 	.wram_A          (ss_wram_A),
 	.wram_D          (ram_q),
@@ -1044,6 +1178,28 @@ savestates savestates_inst (
 	.nvram_WE        (ss_nvram_WE),
 	.nvram_WA        (ss_nvram_WA),
 	.nvram_WD        (ss_nvram_WD),
+	// System E mode (enables VDP2/PSG2/VRAM2 save-restore)
+	.systeme         (systeme),
+	// VDP2 registers (System E)
+	.vdp2_regs       (ss_vdp2_regs),
+	.vdp2_regs_in    (ss_vdp2_regs_in),
+	.vdp2_regs_set   (ss_vdp2_regs_set),
+	// CRAM2 (System E)
+	.cram2_out       (ss_vdp2_cram),
+	.cram2_A         (ss_cram2_A),
+	.cram2_D         (ss_cram2_D),
+	.cram2_wr        (ss_cram2_wr),
+	// VRAM2 DMA (System E)
+	.vram2_en        (ss_vram2_en),
+	.vram2_A         (ss_vram2_A),
+	.vram2_D         (ss_vram2_D),
+	.vram2_WE        (ss_vram2_WE),
+	.vram2_WA        (ss_vram2_WA),
+	.vram2_WD        (ss_vram2_WD),
+	// PSG2 (System E)
+	.psg2_out        (ss_psg2_out),
+	.psg2_in         (ss_psg2_in),
+	.psg2_set        (ss_psg2_set),
 	// DDRAM
 	.DDRAM_ADDR      (ss_ddram_addr),
 	.DDRAM_DIN       (ss_ddram_din),
@@ -1081,8 +1237,12 @@ spram #(.widthad_a(13)) encrypt_key
 	.q(key_d)
 );
 
-assign joy[0] = status[1] ? joy_1[7:0] : joy_0[7:0];
-assign joy[1] = status[1] ? joy_0[7:0] : joy_1[7:0];
+wire ss_hotkey = joy_0[12] | joy_1[12];
+wire [7:0] joy_0_masked = ss_hotkey ? {joy_0[7:4], 4'b0000} : joy_0[7:0];
+wire [7:0] joy_1_masked = ss_hotkey ? {joy_1[7:4], 4'b0000} : joy_1[7:0];
+
+assign joy[0] = status[1] ? joy_1_masked : joy_0_masked;
+assign joy[1] = status[1] ? joy_0_masked : joy_1_masked;
 assign joy[2] = joy_2[7:0];
 assign joy[3] = joy_3[7:0];
 
@@ -1256,6 +1416,9 @@ video video
 	.smode_M1(smode_M1),
 	.smode_M2(smode_M2),
 	.smode_M3(smode_M3),
+	.video_state_out(ss_video_state_out),
+	.video_state_in(ss_video_state_in),
+	.video_state_set(1'b0),
 	.x(x),
 	.y(y),
 	.hsync(HS),
@@ -1270,8 +1433,6 @@ reg ce_vdp;
 reg ce_pix;
 reg ce_sp;
 always @(negedge clk_sys) begin
-	reg [4:0] clkd;
-
 	ce_sp <= clkd[0];
 	ce_vdp <= 0;//div5
 	ce_pix <= 0;//div10
@@ -1313,6 +1474,10 @@ always @(posedge CLK_VIDEO) begin
 	if(~HSync & HS) VSync <= VS;
 end
 
+wire [3:0] vid_r = se_pause_gate ? {1'b0, color[3:1]}  : color[3:0];
+wire [3:0] vid_g = se_pause_gate ? {1'b0, color[7:5]}  : color[7:4];
+wire [3:0] vid_b = se_pause_gate ? {1'b0, color[11:9]} : color[11:8];
+
 video_mixer #(.HALF_DEPTH(1), .LINE_LENGTH(300), .GAMMA(1)) video_mixer
 (
 	.*,
@@ -1321,9 +1486,9 @@ video_mixer #(.HALF_DEPTH(1), .LINE_LENGTH(300), .GAMMA(1)) video_mixer
 	.freeze_sync(),
 
 	.VGA_DE(vga_de),
-	.R((gun_en & gun_target && (~&gun_crosshair)) ? 8'd255 : {2{color[3:0]}}),
-	.G((gun_en & gun_target && (~&gun_crosshair)) ? 8'd0   : {2{color[7:4]}}),
-	.B((gun_en & gun_target && (~&gun_crosshair)) ? 8'd0   : {2{color[11:8]}})
+	.R((gun_en & gun_target && (~&gun_crosshair)) ? 8'd255 : {2{vid_r}}),
+	.G((gun_en & gun_target && (~&gun_crosshair)) ? 8'd0   : {2{vid_g}}),
+	.B((gun_en & gun_target && (~&gun_crosshair)) ? 8'd0   : {2{vid_b}})
 );
 
 
@@ -1343,7 +1508,7 @@ end
 dpram #(.widthad_a(15)) nvram_inst
 (
 	.clock_a     (clk_sys),
-	.address_a   (ss_freeze ? (ss_nvram_WE ? {2'b00, ss_nvram_WA} : {2'b00, ss_nvram_A}) : nvram_a),
+	.address_a   (ss_freeze ? (ss_nvram_WE ? ss_nvram_WA : ss_nvram_A) : nvram_a),
 	.wren_a      (ss_freeze ? ss_nvram_WE : nvram_we),
 	.data_a      (ss_freeze ? ss_nvram_WD : nvram_d),
 	.q_a         (nvram_q),
@@ -1448,7 +1613,7 @@ lightgun lightgun
 
 	.HDE(~HBlank),
 	.VDE(~VBlank),
-	.CE_PIX(ce_pix),
+	.CE_PIX(ss_freeze ? 1'b0 : ce_pix),
 
 	.BTN_MODE(gun_btn_mode),
 	.SIZE(gun_crosshair),

--- a/releases/Astro Flash (Japan).mra
+++ b/releases/Astro Flash (Japan).mra
@@ -23,7 +23,7 @@
 
 	<players>2</players>
 	<joystick>8-way</joystick>
-	<buttons names="Fire/Button1,Transform/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,R,Start,Select" count="1"/>
+	<buttons names="Fire/Button1,Transform/Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Fantasy Zone II - The Tears of Opa-Opa.mra
+++ b/releases/Fantasy Zone II - The Tears of Opa-Opa.mra
@@ -23,7 +23,7 @@
 
 	<players>1</players>
 	<joystick>8-way</joystick>
-	<buttons names="Fire/Button1,Bomb/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,R,Start,Select" count="1"/>
+	<buttons names="Fire/Button1,Bomb/Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Hang On Jr.mra
+++ b/releases/Hang On Jr.mra
@@ -23,7 +23,7 @@
 
 	<players>1</players>
 	<joystick></joystick>
-	<buttons names="-,-,-,-,-,-,Coin,Start,Pause" default="R,Start,Select" count="1"/>
+	<buttons names="-,-,Start,Coin,Pause,-,-,-,SaveState" default="Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Megumi Rescue (Japan).mra
+++ b/releases/Megumi Rescue (Japan).mra
@@ -23,7 +23,7 @@
 
 	<players>2</players>
 	<joystick>8-way</joystick>
-	<buttons names="Launch/Button1,Button2,Button3,-,-,-,Coin,Start,Pause" default="A,B,L,R,Start,Select" count="1"/>
+	<buttons names="Launch/Button1,Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Opa Opa.mra
+++ b/releases/Opa Opa.mra
@@ -23,7 +23,7 @@
 
 	<players>1</players>
 	<joystick>8-way</joystick>
-	<buttons names="Fire1/Button1,Button2,-,-,-,-,Coin,Start,Pause" default="A,B,R,Start,Select" count="2"/>
+	<buttons names="Fire1/Button1,Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="2"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Riddle of Pythagoras (Japan).mra
+++ b/releases/Riddle of Pythagoras (Japan).mra
@@ -23,7 +23,7 @@
 
 	<players>1</players>
 	<joystick>8-way</joystick>
-	<buttons names="Launch/Button1,Button2,-,-,-,-,Coin,Start,Pause" default="A,B,R,Start,Select" count="1"/>
+	<buttons names="Launch/Button1,Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Slap Shooter.mra
+++ b/releases/Slap Shooter.mra
@@ -23,7 +23,7 @@
 
 	<players>1</players>
 	<joystick>8-way</joystick>
-	<buttons names="Pass/Button1,Shot/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,X,Y,R,L,Select,Start" count="1"/>
+	<buttons names="Pass/Button1,Shot/Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Tetris (Japan, System E).mra
+++ b/releases/Tetris (Japan, System E).mra
@@ -23,7 +23,7 @@
 	
 	<players>1</players>
 	<joystick>8-way</joystick>
-	<buttons names="Rotate/Button1,Rotate/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,R,Start,Select" count="1"/>
+	<buttons names="Rotate/Button1,Rotate/Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/releases/Transformer.mra
+++ b/releases/Transformer.mra
@@ -23,7 +23,7 @@
 
 	<players>2</players>
 	<joystick>8-way</joystick>
-	<buttons names="Fire/Button1,Transform/Button2,-,-,-,-,Coin,Start,Pause" default="A,B,R,Start,Select" count="1"/>
+	<buttons names="Fire/Button1,Transform/Button2,Start,Coin,Pause,-,-,-,SaveState" default="A,B,Start,Select,R" count="1"/>
 	
 	<switches base="24" default="FF,FF,FF">
 		<!-- SWA -->

--- a/rtl/T80/T80.vhd
+++ b/rtl/T80/T80.vhd
@@ -118,10 +118,10 @@ entity T80 is
 		IntE       : out std_logic;
 		Stop       : out std_logic;
 		out0       : in  std_logic := '0';  -- 0 => OUT(C),0, 1 => OUT(C),255
-		REG        : out std_logic_vector(211 downto 0); -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+		REG        : out std_logic_vector(229 downto 0); -- Halt_FF, Alternate, WZ, IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
 
 		DIRSet     : in  std_logic := '0';
-		DIR        : in  std_logic_vector(211 downto 0) := (others => '0'); -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+		DIR        : in  std_logic_vector(229 downto 0) := (others => '0'); -- Halt_FF, Alternate, WZ, IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
 		-- Prefix/instruction-set state: '00'=no prefix (clean save point)
 		ISet_out   : out std_logic_vector(1 downto 0)
 	);
@@ -257,14 +257,25 @@ architecture rtl of T80 is
 	signal Halt                 : std_logic;
 	signal XYbit_undoc          : std_logic;
 	signal DOR                  : std_logic_vector(127 downto 0);
+	signal RegDIR               : std_logic_vector(127 downto 0);
 
 begin
 
 	ISet_out <= ISet;
 
-	REG <= IntE_FF2 & IntE_FF1 & IStatus & DOR & std_logic_vector(PC) & std_logic_vector(SP) & std_logic_vector(R) & I & Fp & Ap & F & ACC when Alternate = '0'
-			 else IntE_FF2 & IntE_FF1 & IStatus & DOR(127 downto 112) & DOR(47 downto 0) & DOR(63 downto 48) & DOR(111 downto 64) &
+	REG <= Halt_FF & Alternate & WZ & IntE_FF2 & IntE_FF1 & IStatus & DOR & std_logic_vector(PC) & std_logic_vector(SP) & std_logic_vector(R) & I & Fp & Ap & F & ACC when Alternate = '0'
+			 else Halt_FF & Alternate & WZ & IntE_FF2 & IntE_FF1 & IStatus & DOR(127 downto 112) & DOR(47 downto 0) & DOR(63 downto 48) & DOR(111 downto 64) &
 						std_logic_vector(PC) & std_logic_vector(SP) & std_logic_vector(R) & I & Fp & Ap & F & ACC;
+
+	RegDIR <= DIR(207 downto 80) when DIR(228) = '0' else
+	          DIR(207 downto 192) & -- IY
+	          DIR(127 downto 112) & -- HL
+	          DIR(111 downto 96)  & -- DE
+	          DIR(95 downto 80)   & -- BC
+	          DIR(143 downto 128) & -- IX
+	          DIR(191 downto 176) & -- HL'
+	          DIR(175 downto 160) & -- DE'
+	          DIR(159 downto 144);  -- BC'
 
 	mcode : work.T80_MCode
 		generic map(
@@ -418,11 +429,23 @@ begin
 				SP  <= unsigned(DIR(63 downto 48));
 				PC  <= unsigned(DIR(79 downto 64));
 				A   <= DIR(79 downto 64);
+				WZ  <= DIR(227 downto 212);
 				IStatus <= DIR(209 downto 208);
 				ISet <= "00";
 				XY_State <= "00";
 				XY_Ind <= '0';
-				Alternate <= '0';
+				Alternate <= DIR(228);
+				IR <= "00000000";
+				MCycles <= "001";
+				DO <= "00000000";
+				Read_To_Reg_r <= "00000";
+				Arith16_r <= '0';
+				BTR_r <= '0';
+				Z16_r <= '0';
+				ALU_Op_r <= "0000";
+				Save_ALU_r <= '0';
+				PreserveC_r <= '0';
+				I_RXDD <= '0';
 
 			elsif ClkEn = '1' then
 				ALU_Op_r <= "0000";
@@ -956,7 +979,7 @@ begin
 			DOCL => RegBusC(7 downto 0),
 			DOR  => DOR,
 			DIRSet => DIRSet,
-			DIR  => DIR(207 downto 80));
+			DIR  => RegDIR);
 
 ---------------------------------------------------------------------------
 --
@@ -1087,7 +1110,7 @@ begin
 			if DIRSet = '1' then
 				IntE_FF2 <= DIR(211);
 				IntE_FF1 <= DIR(210);
-				Halt_FF <= '0';
+				Halt_FF <= DIR(229);
 				-- Restart from a clean opcode-fetch cycle after state restore.
 				-- Without this, stale MCycle/TState/IR context from pre-load execution
 				-- can continue with restored registers and cause immediate divergence.

--- a/rtl/T80/T80s.vhd
+++ b/rtl/T80/T80s.vhd
@@ -96,10 +96,10 @@ entity T80s is
 		DI				: in std_logic_vector(7 downto 0);
 		DO				: out std_logic_vector(7 downto 0);
 		-- Save state: snapshot of all Z80 registers
-		-- IFF2,IFF1,IM,IY,HL',DE',BC',IX,HL,DE,BC,PC,SP,R,I,F',A',F,A
-		REG        : out std_logic_vector(211 downto 0);
+		-- WZ,IFF2,IFF1,IM,IY,HL',DE',BC',IX,HL,DE,BC,PC,SP,R,I,F',A',F,A
+		REG        : out std_logic_vector(229 downto 0);
 		DIRSet     : in  std_logic := '0';
-		DIR        : in  std_logic_vector(211 downto 0) := (others => '0');
+		DIR        : in  std_logic_vector(229 downto 0) := (others => '0');
 		-- Prefix/instruction-set state forwarded from T80
 		ISet_out   : out std_logic_vector(1 downto 0)
 	);
@@ -159,7 +159,12 @@ begin
 			MREQ_n <= '1';
 			DI_Reg <= "00000000";
 		elsif rising_edge(CLK) then
-			if CEN = '1' then
+			if DIRSet = '1' then
+				RD_n <= '1';
+				WR_n <= '1';
+				IORQ_n <= '1';
+				MREQ_n <= '1';
+			elsif CEN = '1' then
 				RD_n <= '1';
 				WR_n <= '1';
 				IORQ_n <= '1';

--- a/rtl/io.vhd
+++ b/rtl/io.vhd
@@ -69,6 +69,14 @@ entity io is
 		gg_link_nmi_n:	out STD_LOGIC;
 		systeme:	in  STD_LOGIC;
 		region:	in	 STD_LOGIC;
+		se_mapper_in:  in  STD_LOGIC_VECTOR(7 downto 0) := (others => '0');
+		se_mapper_set: in  STD_LOGIC := '0';
+		vdp_enables:   in  STD_LOGIC_VECTOR(1 downto 0) := (others => '0');
+		psg_enables:   in  STD_LOGIC_VECTOR(1 downto 0) := (others => '0');
+		io_state_out: out STD_LOGIC_VECTOR(31 downto 0);
+		io_state_in:  in  STD_LOGIC_VECTOR(31 downto 0) := (others => '0');
+		io_state_set: in  STD_LOGIC := '0';
+		ss_freeze:     in  STD_LOGIC := '0';
 		RESET_n:	in  STD_LOGIC);
 end io;
 
@@ -177,6 +185,16 @@ begin
 	sk1100_row_sel <= sk1100_port_c(2 downto 0);
 	sk1100_port_a <= sk1100_row_data(7 downto 0);
 	sk1100_port_b <= sk1100_row_data(11 downto 8);
+
+	io_state_out(7 downto 0) <= ctrl;
+	io_state_out(15 downto 8) <= sc_multicart_latch;
+	io_state_out(23 downto 16) <= sk1100_port_c;
+	io_state_out(24) <= analog_select;
+	io_state_out(25) <= analog_player;
+	io_state_out(26) <= analog_upper;
+	io_state_out(28 downto 27) <= vdp_enables;
+	io_state_out(30 downto 29) <= psg_enables;
+	io_state_out(31) <= '0';
 
 	process (clk, RESET_n)
 	begin
@@ -319,7 +337,7 @@ begin
 				gg_nmi_serial <= '0';
 			end if;
 
-			if gg='1' and A(7 downto 3) = "00000" then
+			if ss_freeze = '0' and gg='1' and A(7 downto 3) = "00000" then
 				if WR_n='0' then
 					case A(2 downto 0) is
 						when "001" =>
@@ -363,24 +381,24 @@ begin
 						when others => null ;
 					end case;
 				end if;
-			elsif systeme='1' and A = x"F7" then
+			elsif ss_freeze = '0' and systeme='1' and A = x"F7" then
 				if WR_n='0' then
 					vdp1_bank <= D_in(7);
 					vdp2_bank <= D_in(6);
 					vdp_cpu_bank <= D_in(5);
 					rom_bank <= D_in(3 downto 0);
 				end if;
-			elsif systeme='1' and A = x"FA" then
+			elsif ss_freeze = '0' and systeme='1' and A = x"FA" then
 				if WR_n='0' then
 					analog_player <= D_in(3); -- paddle select ridleofp
 					analog_upper  <= D_in(2); -- upperbits ridleofp
 					analog_select <= D_in(0); -- analog select(paddle, pedal) hangonjr
 				end if;
-			elsif sc_multicart_en='1' and A(7 downto 5)="111" then
+			elsif ss_freeze = '0' and sc_multicart_en='1' and A(7 downto 5)="111" then
 				if WR_n='0' then
 					sc_multicart_latch <= D_in;
 				end if;
-			elsif sg_mode='1' and sk1100_active='1' and A(7 downto 5)="110" then
+			elsif ss_freeze = '0' and sg_mode='1' and sk1100_active='1' and A(7 downto 5)="110" then
 				if WR_n='0' then
 					case A(1 downto 0) is
 						when "10" =>
@@ -393,11 +411,11 @@ begin
 							null;
 					end case;
 				end if;
-			elsif sg_mode='1' and sk1100_active='0' and (A = x"DE" or A = x"DF") then
+			elsif ss_freeze = '0' and sg_mode='1' and sk1100_active='0' and (A = x"DE" or A = x"DF") then
 				-- Plain SG-1000 carts don't have the SC-3000/SK-1100 PPI attached.
 				-- Ignore these writes so they don't accidentally hit the SMS control port.
 				null;
-			elsif A(0)='1' then
+			elsif ss_freeze = '0' and A(0)='1' then
 --				if WR_n='0' and ((A(7 downto 4)/="0000") or (A(3 downto 0)="0000")) then
 				if WR_n='0' then
 					ctrl <= D_in;
@@ -407,6 +425,21 @@ begin
 				gg_tx_wr_d <= '1';
 			else
 				gg_tx_wr_d <= '0';
+			end if;
+			-- savestate restore: System E IO port 0xF7 state
+			if se_mapper_set = '1' then
+				vdp1_bank    <= se_mapper_in(7);
+				vdp2_bank    <= se_mapper_in(6);
+				vdp_cpu_bank <= se_mapper_in(5);
+				rom_bank     <= se_mapper_in(3 downto 0);
+			end if;
+			if io_state_set = '1' then
+				ctrl               <= io_state_in(7 downto 0);
+				sc_multicart_latch <= io_state_in(15 downto 8);
+				sk1100_port_c      <= io_state_in(23 downto 16);
+				analog_select      <= io_state_in(24);
+				analog_player      <= io_state_in(25);
+				analog_upper       <= io_state_in(26);
 			end if;
 		end if;
 	end process;

--- a/rtl/savestate_ui.sv
+++ b/rtl/savestate_ui.sv
@@ -4,7 +4,7 @@
 // combos into one-cycle ss_save / ss_load pulses and slot selection.
 //
 // Info message indices for hps_io (1-based; 0 = no display):
-//   1    : hint message ("Slot=LR|Save=Pause+Down|Load=Pause+Up")
+//   1    : hint message ("Slot=LR|Save=SS+Down|Load=SS+Up")
 //   2-5  : "Active Slot 1..4"
 //   6,8,10,12 : "Save to state 1..4"
 //   7,9,11,13 : "Restore state 1..4"
@@ -16,8 +16,8 @@
 // Gamepad combos (SaveState button = joy[12]):
 //   SS + Left              → switch to prev slot
 //   SS + Right             → switch to next slot
-//   SS + Pause + Down      → save state
-//   SS + Pause + Up        → load state
+//   SS + Down              → save state
+//   SS + Up                → load state
 //
 // PS/2 keyboard:  F1 = load state,  Alt+F1 = save state
 
@@ -67,6 +67,8 @@ reg                  ss_combo_done; // combo or timeout already fired this press
 // OSD edge trackers
 reg old_osd_save, old_osd_load;
 
+reg [27:0] cooldown_cnt = 0;
+
 // -----------------------------------------------------------------------
 // PS/2 keyboard: F1 = load,  Alt+F1 = save
 // -----------------------------------------------------------------------
@@ -89,6 +91,11 @@ end
 // Main logic: OSD / keyboard / gamepad
 // -----------------------------------------------------------------------
 always @(posedge clk) begin
+    // Cooldown timer decrement
+    if (cooldown_cnt != 0) begin
+        cooldown_cnt <= cooldown_cnt - 28'd1;
+    end
+
     // Defaults
     ss_save              <= 0;
     ss_load              <= 0;
@@ -129,7 +136,7 @@ always @(posedge clk) begin
 
     // Sync slot when user changes it through the OSD menu
     old_status_slot <= status_slot;
-    if (status_slot != old_status_slot)
+    if (status_slot != old_status_slot && (cooldown_cnt == 0))
         slot <= status_slot;
 
     // selected_slot tracks slot with 1-cycle lag; aligned with statusUpdate
@@ -139,60 +146,68 @@ always @(posedge clk) begin
     old_osd_save <= OSD_saveload[0];
     old_osd_load <= OSD_saveload[1];
 
-    if (~old_osd_save & OSD_saveload[0] & allow_ss) begin
-        ss_save     <= 1;
-        ss_info_req <= 1;
-        ss_info     <= 8'd6 + {slot, 1'b0};   // "Save to state N"  (1-based: 6,8,10,12)
+    if (~old_osd_save & OSD_saveload[0] & allow_ss && (cooldown_cnt == 0)) begin
+        ss_save      <= 1;
+        ss_info_req  <= 1;
+        ss_info      <= 8'd6 + {slot, 1'b0};   // "Save to state N"  (1-based: 6,8,10,12)
+        cooldown_cnt <= 28'd26846500;          // 500ms cooldown
     end
-    if (~old_osd_load & OSD_saveload[1] & allow_ss) begin
-        ss_load     <= 1;
-        ss_info_req <= 1;
-        ss_info     <= 8'd7 + {slot, 1'b0};   // "Restore state N"  (1-based: 7,9,11,13)
+    if (~old_osd_load & OSD_saveload[1] & allow_ss && (cooldown_cnt == 0)) begin
+        ss_load      <= 1;
+        ss_info_req  <= 1;
+        ss_info      <= 8'd7 + {slot, 1'b0};   // "Restore state N"  (1-based: 7,9,11,13)
+        cooldown_cnt <= 28'd26846500;          // 500ms cooldown
     end
 
     // PS/2 keyboard shortcuts
-    if (kbd_save & allow_ss) begin
-        ss_save     <= 1;
-        ss_info_req <= 1;
-        ss_info     <= 8'd6 + {slot, 1'b0};
+    if (kbd_save & allow_ss && (cooldown_cnt == 0)) begin
+        ss_save      <= 1;
+        ss_info_req  <= 1;
+        ss_info      <= 8'd6 + {slot, 1'b0};
+        cooldown_cnt <= 28'd26846500;          // 500ms cooldown
     end
-    if (kbd_load & allow_ss) begin
-        ss_load     <= 1;
-        ss_info_req <= 1;
-        ss_info     <= 8'd7 + {slot, 1'b0};
+    if (kbd_load & allow_ss && (cooldown_cnt == 0)) begin
+        ss_load      <= 1;
+        ss_info_req  <= 1;
+        ss_info      <= 8'd7 + {slot, 1'b0};
+        cooldown_cnt <= 28'd26846500;          // 500ms cooldown
     end
 
     // Gamepad combos — only when the dedicated SaveState button is held
     if (joySS) begin
         // Rising edge of Left (no Pause): previous slot
-        if (~joyLeft_r & joyLeft & ~joyPause) begin
+        if (~joyLeft_r & joyLeft & ~joyPause && (cooldown_cnt == 0)) begin
             slot                 <= (slot == 2'd0) ? 2'd3 : slot - 2'd1;
             statusUpdate_pending <= 1;
             ss_info_req          <= 1;
             ss_info              <= 8'd2 + ((slot == 2'd0) ? 2'd3 : slot - 2'd1);
             ss_combo_done        <= 1;
+            cooldown_cnt         <= 28'd26846500;  // 500ms slot cooldown
         end
         // Rising edge of Right (no Pause): next slot
-        if (~joyRight_r & joyRight & ~joyPause) begin
+        if (~joyRight_r & joyRight & ~joyPause && (cooldown_cnt == 0)) begin
             slot                 <= (slot == 2'd3) ? 2'd0 : slot + 2'd1;
             statusUpdate_pending <= 1;
             ss_info_req          <= 1;
             ss_info              <= 8'd2 + ((slot == 2'd3) ? 2'd0 : slot + 2'd1);
             ss_combo_done        <= 1;
+            cooldown_cnt         <= 28'd26846500;  // 500ms slot cooldown
         end
-        // Rising edge of Down while Pause held: save
-        if (joyPause & ~joyDown_r & joyDown & allow_ss) begin
+        // Rising edge of Down (no Pause needed): save
+        if (~joyDown_r & joyDown & ~joyLeft & ~joyRight & allow_ss && (cooldown_cnt == 0)) begin
             ss_save       <= 1;
             ss_info_req   <= 1;
             ss_info       <= 8'd6 + {slot, 1'b0};
             ss_combo_done <= 1;
+            cooldown_cnt  <= 28'd26846500;      // 500ms cooldown
         end
-        // Rising edge of Up while Pause held: load
-        if (joyPause & ~joyUp_r & joyUp & allow_ss) begin
+        // Rising edge of Up (no Pause needed): load
+        if (~joyUp_r & joyUp & ~joyLeft & ~joyRight & allow_ss && (cooldown_cnt == 0)) begin
             ss_load       <= 1;
             ss_info_req   <= 1;
             ss_info       <= 8'd7 + {slot, 1'b0};
             ss_combo_done <= 1;
+            cooldown_cnt  <= 28'd26846500;      // 500ms cooldown
         end
     end
 end

--- a/rtl/savestates.sv
+++ b/rtl/savestates.sv
@@ -3,18 +3,25 @@
 //
 // Memory layout (DDRAM word addresses, slot n base = 0x3E000000 + n*0x10000):
 //   Word 0x000: MiSTer SS control word [31:0]=change_det, [63:32]=size_in_32b_words
-//   Word 0x001: magic "SMS1" (0x534D5331)
+//   Word 0x001: [31:0]=magic ("SMS1"/"SMSB"), [63:32]=game signature
 //   Word 0x002-0x005: Z80 REG[211:0]   (4 × 64-bit words, MSBs unused)
 //   Word 0x006-0x007: VDP regs [127:0] (2 × 64-bit words)
 //   Word 0x008-0x00D: CRAM [383:0]     (6 × 64-bit words)
 //   Word 0x00E:       PSG  [55:0]      (1 × 64-bit word, upper 8 bits unused)
 //   Word 0x00F:       Mapper [63:0]    (1 × 64-bit word)
+//   Word 0x010-0x011: VDP2 regs [127:0] (System E only; 2 × 64-bit words)
+//   Word 0x012-0x017: CRAM2 [383:0]   (System E only; 6 × 64-bit words)
+//   Word 0x018:       PSG2 [55:0]     (System E only; 1 × 64-bit word)
 //   Words 0x101-0x900: VRAM 16KB       (2048 × 64-bit words)
-//   Words 0x901-0xD00: WRAM 8KB        (1024 × 64-bit words)
-//   Words 0xD01-0x1100: NVRAM 8KB (Dahjee A only)
+//   Words 0x901-0xD00: WRAM 8KB        (1024 × 64-bit words) [SMS/GG]
+//   Words 0x901-0x1100: WRAM 16KB      (2048 × 64-bit words) [System E; reuses NVRAM region]
+//   Words 0xD01-0x1100: NVRAM 8KB (Dahjee A only; mutually exclusive with System E)
+//   Words 0x1101-0x1900: VRAM2 16KB    (System E only; 2048 × 64-bit words)
+//   Words 0x1901-0x2100: VDP1 passive 16KB (System E only; inline; written to SD)
+//   Words 0x2101-0x2900: VDP2 passive 16KB (System E only; inline; written to SD)
 //
-// Slot size = 0x2000 words = 64KB.  Up to 4 slots.
-// Base word address = 29'h07C00000 + slot * 29'h2000
+// Slot size = 0x3000 words = 96KB.  Up to 4 slots.
+// Base word address = 29'h07C00000 + slot * 29'h3000
 
 module savestates (
     input             clk,
@@ -25,6 +32,7 @@ module savestates (
     input             ss_load,         // one-cycle load pulse
     input       [1:0] ss_slot,
     input             ss_bios_mode,    // 1 when running BIOS without cart
+    input      [31:0] ss_game_id,      // ROM signature (reject cross-ROM loads)
 
     // Freeze: hold '1' to pause CPU + VDP clock enables
     output reg        ss_freeze,
@@ -32,10 +40,11 @@ module savestates (
     // VBlank level from video.vhd (not gated by ss_freeze)
     // Used to defer unfreeze until a clean frame boundary after load
     input             vblank,
+    input       [8:0] x,
 
     // ---- Z80 snapshot / restore ----
-    input     [211:0] z80_reg,         // live snapshot from T80s
-    output reg [211:0] z80_dir,        // restore data
+    input     [229:0] z80_reg,         // live snapshot from T80s
+    output reg [229:0] z80_dir,        // restore data
     output reg        z80_set,         // one-cycle restore strobe
     input             z80_m1_n,        // Z80 M1 cycle (low = opcode fetch in progress)
     // '0' = memory request = normal opcode fetch; '1' = interrupt acknowledge (skip!)
@@ -46,6 +55,10 @@ module savestates (
     input             cpu_ce,
     // Raw VDP clock-enable pulse (ungated by ss_freeze)
     input             vdp_ce,
+    // Raw PIX clock-enable pulse (ungated by ss_freeze)
+    input             pix_ce,
+    // Raw SP clock-enable pulse (ungated by ss_freeze)
+    input             sp_ce,
 
     // ---- VDP registers ----
     input     [127:0] vdp_regs,
@@ -83,13 +96,49 @@ module savestates (
     output reg [13:0] wram_WA,
     output reg  [7:0] wram_WD,
 
-    // ---- NVRAM DMA (Dahjee A expansion RAM, 8KB at $2000-$3FFF) ----
-    // Only saved/restored when mapper_snap[48] (detect_dahjee_a) is set.
-    output reg [12:0] nvram_A,          // read address
+    // ---- NVRAM DMA (SRAM / NVRAM, up to 32KB) ----
+    output reg [14:0] nvram_A,          // read address
     input       [7:0] nvram_D,          // read data
     output reg        nvram_WE,
-    output reg [12:0] nvram_WA,
+    output reg [14:0] nvram_WA,
     output reg  [7:0] nvram_WD,
+
+    // ---- System E mode (enables VDP2 / PSG2 / VRAM2 save-restore) ----
+    input             systeme,
+
+    // ---- VDP2 registers (System E second VDP) ----
+    input     [127:0] vdp2_regs,
+    output reg [127:0] vdp2_regs_in,
+    output reg        vdp2_regs_set,
+
+    // ---- CRAM2 (System E second VDP colour RAM) ----
+    input     [383:0] cram2_out,
+    output reg  [4:0] cram2_A,
+    output reg [11:0] cram2_D,
+    output reg        cram2_wr,
+
+    // ---- VRAM2 DMA (port A of dpram in vdp2, muxed when freeze) ----
+    output reg        vram2_en,
+    output reg [14:0] vram2_A,
+    input       [7:0] vram2_D,
+    output reg        vram2_WE,
+    output reg [14:0] vram2_WA,
+    output reg  [7:0] vram2_WD,
+
+    // ---- PSG2 snapshot / restore (System E second PSG) ----
+    input      [55:0] psg2_out,
+    output reg [55:0] psg2_in,
+    output reg        psg2_set,
+
+    // ---- IO snapshot / restore ----
+    input      [31:0] io_out,
+    output reg [31:0] io_in,
+    output reg        io_set,
+
+    // ---- Video State snapshot / restore ----
+    input      [21:0] video_state_out,
+    output reg [21:0] video_state_in,
+    output reg        video_state_set,
 
     // ---- DDRAM interface ----
     output reg [28:0] DDRAM_ADDR,
@@ -109,19 +158,20 @@ module savestates (
 localparam [31:0] MAGIC = 32'h534D5331; // "SMS1"
 localparam [31:0] MAGIC_BIOS = 32'h534D5342; // "SMSB"
 
-// Slot base word address for cartridge savestates (slots 0-3)
+// Slot base word address for cartridge savestates (slots 0-3).
+// Slot size 0x3000 words (96KB) to accommodate inline passive VRAM banks.
 function automatic [28:0] slot_base;
     input [1:0] slot;
-    slot_base = 29'h07C00000 + {27'd0, slot} * 29'h2000;
+    slot_base = 29'h07C00000 + {27'd0, slot} * 29'h3000;
 endfunction
 
-// Slot base word address for BIOS savestates (slots 4-7).
-// Placed after the 4 game slots so game and BIOS state never share the same
-// DDRAM words. Addresses here are outside the CONF_STR SS range so the
+// Slot base word address for BIOS savestates.
+// Placed after the 4 game slots (4 × 0x3000 = 0xC000 words above base).
+// Addresses here are outside the CONF_STR SS range so the
 // MiSTer ARM side will not write them to disk -- BIOS states are DDRAM-only.
 function automatic [28:0] bios_slot_base;
     input [1:0] slot;
-    bios_slot_base = 29'h07C08000 + {27'd0, slot} * 29'h2000;
+    bios_slot_base = 29'h07C0C000 + {27'd0, slot} * 29'h3000;
 endfunction
 
 // -----------------------------------------------------------------------
@@ -130,6 +180,8 @@ endfunction
 localparam ST_IDLE         = 6'd0;
 localparam ST_WAIT_BOUNDARY= 6'd37;  // wait for Z80 instruction boundary (M1)
 localparam ST_ARM_FREEZE   = 6'd41;  // assert freeze so it is active before next CE pulse
+localparam ST_FREEZE_DRAIN = 6'd54;  // drain in-flight DDRAM replies before SS transactions
+localparam ST_SAVE_SETTLE  = 6'd55;  // short DDRAM settle after final save write
 localparam ST_FREEZE       = 6'd1;
 localparam ST_SAVE_HDR     = 6'd2;
 localparam ST_SAVE_CPU0    = 6'd3;
@@ -162,10 +214,45 @@ localparam ST_LOAD_WRAM    = 6'd32;
 localparam ST_LOAD_RESTORE = 6'd33;
 localparam ST_UNFREEZE     = 6'd34;
 localparam ST_SAVE_NVRAM   = 6'd35;
+localparam ST_PRE_UNFREEZE = 6'd56;
 localparam ST_LOAD_NVRAM   = 6'd36;
 localparam ST_WAIT_VBLANK  = 6'd38;  // wait for VBlank before unfreeze (load path)
 localparam ST_WAIT_RESTORE_BOUNDARY = 6'd39;  // one-cycle mapper-settle phase before core restore
 localparam ST_ERROR        = 6'd40;  // error state - unfreeze and return to idle
+// System E extra states
+localparam ST_SAVE_VDP2REG = 6'd42;  // save VDP2 registers
+localparam ST_SAVE_CRAM2   = 6'd43;  // save VDP2 CRAM
+localparam ST_SAVE_PSG2    = 6'd44;  // save PSG2
+localparam ST_SAVE_VRAM2   = 6'd45;  // save VRAM2 DMA
+localparam ST_LOAD_VDP2REG = 6'd46;  // load VDP2 registers
+localparam ST_LOAD_CRAM2   = 6'd47;  // load VDP2 CRAM
+localparam ST_LOAD_PSG2    = 6'd48;  // load PSG2
+localparam ST_LOAD_VRAM2   = 6'd49;  // load VRAM2 DMA
+localparam ST_LOAD_VRAM1_PASSIVE = 6'd50; // load/zero-fill VDP1 passive bank (System E)
+localparam ST_LOAD_VRAM2_PASSIVE = 6'd51; // load/zero-fill VDP2 passive bank (System E)
+localparam ST_SAVE_VRAM1_PASSIVE = 6'd52; // save VDP1 passive bank to DDRAM (System E)
+localparam ST_SAVE_VRAM2_PASSIVE = 6'd53; // save VDP2 passive bank to DDRAM (System E)
+localparam ST_SAVE_IO            = 6'd57;
+localparam ST_LOAD_IO            = 6'd58;
+localparam ST_FLUSH_PIPELINE     = 6'd59;
+localparam ST_SAVE_VIDEO         = 6'd60;
+localparam ST_LOAD_VIDEO         = 6'd61;
+localparam ST_LOAD_HDR_WT2       = 6'd62;
+localparam ST_UNFREEZE_SETTLE = 6'd63;
+
+// Post-op guard time to avoid pathological immediate re-entry (rapid hammering).
+localparam [27:0] OP_COOLDOWN_MAX = 28'd26846500; // ~500ms @ 53.7MHz
+localparam [19:0] FLUSH_MAX       = 20'd900000;    // ≈16.8ms @ 53.7MHz
+
+// NVRAM size calculation helpers
+wire has_nvram_8k  = mapper_snap[48] | mapper_snap[53]; // Dahjee A / Codemasters CME
+wire has_nvram_16k = mapper_snap[50];                   // Sega mapper nvram_e
+wire has_nvram_32k = mapper_snap[51] | mapper_snap[52] | mapper_snap[61]; // nvram_ex / nvram_p / The Castle
+wire has_nvram     = has_nvram_8k | has_nvram_16k | has_nvram_32k;
+
+wire [14:0] nvram_size_minus_1 = has_nvram_32k ? 15'd32767 :
+                                 has_nvram_16k ? 15'd16383 :
+                                                 15'd8191;
 
 reg [5:0]  state;
 reg        do_save;     // 1=save, 0=load
@@ -173,20 +260,30 @@ reg [1:0]  cur_slot;
 reg [28:0] base_addr;
 reg [31:0] ss_change_det; // MiSTer framework change detector (increment to trigger save-to-disk)
 reg [31:0] cur_magic;
+reg [31:0] cur_game_id;
 reg        cur_bios_mode;
 
 // counters
-reg [10:0] word_cnt;    // general DMA word counter
+reg [11:0] word_cnt;    // general DMA word counter (expanded to 12 bits for 32KB NVRAM)
 reg  [2:0] cram_idx;    // 0..5 for CRAM 64-bit words
 reg  [4:0] cram_entry;  // 0..31 for entry-by-entry restore
 reg  [2:0] cpu_idx;     // 0..3 for CPU words
 reg  [2:0] vdp_idx;     // 0..1 for VDP reg words
+reg  [19:0] flush_cnt;  // expanded to 20 bits for 900000 cycles
+reg  [7:0] unfreeze_cnt; // expanded to 8 bits for 255 cycles
+reg  [21:0] align_timeout;
 // Latching buffers for multi-word state
-reg [211:0] z80_snap;
+reg [229:0] z80_snap;
 reg [127:0] vdp_snap;
 reg [383:0] cram_snap;
 reg  [55:0] psg_snap;
 reg  [63:0] mapper_snap;
+// System E latching buffers
+reg [127:0] vdp2_snap;
+reg [383:0] cram2_snap;
+reg  [55:0] psg2_snap;
+reg  [31:0] io_snap;
+reg  [21:0] video_snap;
 
 // VRAM DMA pipelining: address issued, wait 2 clocks for data
 reg  [2:0]  vram_pipe;
@@ -211,9 +308,9 @@ reg         wram_load_active; // 1 while writing 8 bytes from dout_latch
 reg  [7:0]  wram_d_latch;
 reg         wram_d_latched;
 
-// NVRAM DMA (8KB Dahjee A expansion RAM)
-reg [12:0]  nvram_save_addr;
-reg [12:0]  nvram_load_addr;
+// NVRAM DMA (SRAM / NVRAM, up to 32KB)
+reg [14:0]  nvram_save_addr;
+reg [14:0]  nvram_load_addr;
 reg  [2:0]  nvram_byte_cnt;
 reg [63:0]  nvram_word_buf;
 reg  [1:0]  nvram_pipe;
@@ -235,8 +332,13 @@ reg         dout_expected;
 reg [24:0]  ddram_watchdog;
 localparam  DDRAM_WATCHDOG_MAX = 25'h1FFFFFF;
 
+// Drain window after taking DDRAM ownership from scaler/video path.
+reg [5:0]   freeze_drain_cnt;
+
 // VBlank edge-detection for clean unfreeze
 reg         vblank_seen;   // goes 1 once we have seen vblank=1 in ST_WAIT_VBLANK
+reg [27:0]  op_cooldown;
+reg         is_old_format;
 
 // -----------------------------------------------------------------------
 // DDRAM helper tasks (inline)
@@ -283,6 +385,7 @@ always @(posedge clk or negedge reset_n) begin
         ss_freeze       <= 0;
         ss_change_det   <= 0;
         cur_magic       <= MAGIC;
+        cur_game_id     <= 0;
         cur_bios_mode   <= 0;
         z80_set         <= 0;
         vdp_regs_set    <= 0;
@@ -296,10 +399,27 @@ always @(posedge clk or negedge reset_n) begin
         wram_load_active <= 0;
         nvram_WE        <= 0;
         nvram_load_active <= 0;
+        vdp2_regs_set   <= 0;
+        cram2_wr        <= 0;
+        psg2_set        <= 0;
+        vram2_en        <= 0;
+        vram2_WE        <= 0;
         dout_latch      <= 64'd0;
+        io_in           <= 32'd0;
+        io_set          <= 0;
+        io_snap         <= 32'd0;
+        video_state_in  <= 22'd0;
+        video_state_set <= 0;
+        video_snap      <= 22'd0;
         vblank_seen     <= 0;
         dout_expected   <= 0;
         ddram_watchdog  <= 0;
+        freeze_drain_cnt <= 0;
+        op_cooldown    <= 0;
+        is_old_format   <= 0;
+        flush_cnt       <= 0;
+        unfreeze_cnt    <= 0;
+        align_timeout   <= 0;
         DDRAM_WE        <= 0;
         DDRAM_RD        <= 0;
         DDRAM_BURSTCNT  <= 8'd1;
@@ -313,6 +433,12 @@ always @(posedge clk or negedge reset_n) begin
         vram_WE      <= 0;
         wram_WE      <= 0;
         nvram_WE     <= 0;
+        vdp2_regs_set <= 0;
+        cram2_wr     <= 0;
+        psg2_set     <= 0;
+        vram2_WE     <= 0;
+        io_set       <= 0;
+        video_state_set <= 0;
         ddram_idle();
 
         // DDRAM read watchdog: abort if no response after ~640ms
@@ -331,7 +457,10 @@ always @(posedge clk or negedge reset_n) begin
         ST_IDLE: begin
             ss_freeze   <= 0;
             vblank_seen <= 0;  // reset for next VBlank wait
-            if (ss_save) begin
+            is_old_format <= 0;
+             if (op_cooldown != 0)
+                 op_cooldown <= op_cooldown - 28'd1;
+            else if (ss_save) begin
                 do_save   <= 1;
                 cur_slot  <= ss_slot;
                 state     <= ST_WAIT_BOUNDARY;
@@ -344,26 +473,25 @@ always @(posedge clk or negedge reset_n) begin
 
         // ---------------------------------------------------------------
         ST_WAIT_BOUNDARY: begin
-            // Wait for a clean Z80 instruction boundary:
+            // Wait for a clean Z80 instruction boundary during VBlank.
+            // This ensures both save and load freeze the system at a clean
+            // instruction boundary during the VBlank phase, avoiding mid-frame
+            // raster-timing inconsistencies.
             //   - M1_n low  : opcode-fetch machine cycle
             //   - MREQ_n low: normal memory read (not interrupt acknowledge)
             //   - ISet=00   : no prefix active (not mid-way through CB/DD/ED/FD sequence)
             //   - cpu_ce     : only act on an actual CPU tick, not on held bus
             //                  levels between ticks.
-            if (cpu_ce && !z80_m1_n && !z80_mreq_n && z80_iset == 2'b00) begin
+            if (cpu_ce && !z80_m1_n && !z80_mreq_n && z80_iset == 2'b00 && vblank && x < 9'd256) begin
                 base_addr <= ss_bios_mode ? bios_slot_base(cur_slot) : slot_base(cur_slot);
                 cur_bios_mode <= ss_bios_mode;
                 cur_magic <= ss_bios_mode ? MAGIC_BIOS : MAGIC;
+                cur_game_id <= ss_game_id;
 
-                // Capture snapshot in the same cycle the boundary is detected.
-                // Capturing one cycle later can occasionally grab post-boundary
-                // state (or partially advanced mapper/VDP side effects), creating
-                // non-deterministic loads that crash or glitch.
+                // Z80 snapshot MUST be captured in the same cycle the boundary is detected.
+                // Capturing one cycle later grabs the post-tick state (where PC is already
+                // incremented), creating non-deterministic loads that skip an instruction.
                 z80_snap    <= z80_reg;
-                vdp_snap    <= vdp_regs;
-                cram_snap   <= cram_out;
-                psg_snap    <= psg_out;
-                mapper_snap <= mapper_out;
                 state       <= ST_ARM_FREEZE;
             end
         end
@@ -372,9 +500,40 @@ always @(posedge clk or negedge reset_n) begin
         ST_ARM_FREEZE: begin
             // Freeze is asserted one clk_sys cycle after boundary detection so
             // it is guaranteed active before the next CPU/VDP CE pulse.
-            // This prevents one extra micro-step after snapshot capture.
-            ss_freeze <= 1;
-            state     <= ST_FREEZE;
+            // We capture VDP/PSG snapshots here (one cycle late) so they reflect
+            // the post-tick state. This ensures they are perfectly synchronized
+            // with the internal x/y counters (which also advanced on the boundary tick
+            // and are not saved/restored, but merely frozen).
+            vdp_snap    <= vdp_regs;
+            cram_snap   <= cram_out;
+            psg_snap    <= psg_out;
+            mapper_snap <= mapper_out;
+            if (systeme) begin
+                vdp2_snap   <= vdp2_regs;
+                cram2_snap  <= cram2_out;
+                psg2_snap   <= psg2_out;
+            end
+            io_snap          <= io_out;
+            video_snap       <= video_state_out;
+            
+            ss_freeze        <= 1;
+            freeze_drain_cnt <= 0;
+            state            <= ST_FREEZE_DRAIN;
+        end
+
+        // ---------------------------------------------------------------
+        ST_FREEZE_DRAIN: begin
+            // After switching DDRAM ownership, wait for a clean idle window:
+            // no bus busy and no read-data pulses for 32 consecutive clocks.
+            // This is more robust than a blind fixed delay under heavy load.
+            ss_freeze     <= 1;
+            dout_expected <= 0;
+            if (DDRAM_BUSY || DDRAM_DOUT_READY)
+                freeze_drain_cnt <= 0;
+            else if (freeze_drain_cnt == 6'd31)
+                state <= ST_FREEZE;
+            else
+                freeze_drain_cnt <= freeze_drain_cnt + 6'd1;
         end
 
         // ---------------------------------------------------------------
@@ -389,9 +548,21 @@ always @(posedge clk or negedge reset_n) begin
             // to settle before loading CPU/VDP/PSG. This avoids occasional
             // resumes with stale ROM mapping or BIOS/cart decode for the first
             // restored core cycle.
-            mapper_in  <= mapper_snap;
-            mapper_set <= 1;
-            state      <= ST_LOAD_RESTORE;
+            if (!DDRAM_BUSY) begin
+                mapper_in  <= mapper_snap;
+                mapper_set <= 1;
+                if (has_nvram) begin
+                    nvram_load_addr   <= 0;
+                    nvram_byte_cnt    <= 0;
+                    nvram_load_active <= 0;
+                    word_cnt          <= 0;
+                    ddram_read(base_addr + 29'h0D01);
+                    state             <= ST_LOAD_NVRAM;
+                end else begin
+                    state             <= ST_LOAD_RESTORE;
+                    cram_entry        <= 0;
+                end
+            end
         end
 
         // ===============================================================
@@ -400,20 +571,20 @@ always @(posedge clk or negedge reset_n) begin
 
         ST_SAVE_HDR: begin
             if (!DDRAM_BUSY) begin
-                ddram_write(base_addr + 29'd1, {32'd0, cur_magic}, 8'h0F);
+                ddram_write(base_addr + 29'd1, {cur_game_id, cur_magic}, 8'hFF);
                 state <= ST_SAVE_CPU0;
                 cpu_idx <= 0;
             end
         end
 
         ST_SAVE_CPU0: begin
-            // z80_snap[211:0] = 212 bits → 4 × 64-bit words (w0..w2 = 192 bits + w3 spare 20 bits)
+            // z80_snap[228:0] = 229 bits → 4 × 64-bit words
             if (!DDRAM_BUSY) begin
                 case (cpu_idx)
                     3'd0: ddram_write(base_addr + 29'd2, z80_snap[63:0],    8'hFF);
                     3'd1: ddram_write(base_addr + 29'd3, z80_snap[127:64],  8'hFF);
                     3'd2: ddram_write(base_addr + 29'd4, z80_snap[191:128], 8'hFF);
-                    3'd3: ddram_write(base_addr + 29'd5, {52'd0, z80_snap[211:192]}, 8'hFF);
+                    3'd3: ddram_write(base_addr + 29'd5, {26'd0, z80_snap[229:192]}, 8'hFF);
                 endcase
                 if (cpu_idx == 3) begin
                     state   <= ST_SAVE_VDP0;
@@ -466,14 +637,86 @@ always @(posedge clk or negedge reset_n) begin
         ST_SAVE_MAPPER: begin
             if (!DDRAM_BUSY) begin
                 ddram_write(base_addr + 29'd15, mapper_snap, 8'hFF);
-                // Start VRAM DMA: 16384 bytes → 2048 × 64-bit words
-                // DDRAM offset 0x100 words from base
-                vram_save_addr <= 0;
+                state <= ST_SAVE_IO;
+            end
+        end
+
+        ST_SAVE_IO: begin
+            if (!DDRAM_BUSY) begin
+                ddram_write(base_addr + 29'h019, {32'd0, io_snap}, 8'hFF);
+                state <= ST_SAVE_VIDEO;
+            end
+        end
+
+        ST_SAVE_VIDEO: begin
+            if (!DDRAM_BUSY) begin
+                ddram_write(base_addr + 29'h01a, {42'd0, video_snap}, 8'hFF);
+                if (systeme) begin
+                    // System E: save VDP2/CRAM2/PSG2 before VRAM1
+                    cram_idx  <= 0;
+                    vdp_idx   <= 0;
+                    state     <= ST_SAVE_VDP2REG;
+                end else begin
+                    // Start VRAM DMA: 16384 bytes → 2048 × 64-bit words
+                    // DDRAM offset 0x100 words from base
+                    vram_save_addr <= 0;
+                    vram_byte_cnt  <= 0;
+                    vram_word_buf  <= 0;
+                    vram_pipe      <= 0;
+                    vram_en        <= 1;
+                    vram_A         <= 0;
+                    word_cnt       <= 0;
+                    vram_d_latched <= 0;
+                    state          <= ST_SAVE_VRAM;
+                end
+            end
+        end
+
+        ST_SAVE_VDP2REG: begin
+            if (!DDRAM_BUSY) begin
+                case (vdp_idx[0])
+                    1'b0: ddram_write(base_addr + 29'h10, vdp2_snap[63:0],   8'hFF);
+                    1'b1: ddram_write(base_addr + 29'h11, vdp2_snap[127:64], 8'hFF);
+                endcase
+                if (vdp_idx[0] == 1) begin
+                    cram_idx <= 0;
+                    state    <= ST_SAVE_CRAM2;
+                end else
+                    vdp_idx[0] <= 1'b1;
+            end
+        end
+
+        ST_SAVE_CRAM2: begin
+            // 6 words × 64-bit = 384 bits = CRAM2
+            if (!DDRAM_BUSY) begin
+                case (cram_idx)
+                    3'd0: ddram_write(base_addr + 29'h12, cram2_snap[ 63:  0], 8'hFF);
+                    3'd1: ddram_write(base_addr + 29'h13, cram2_snap[127: 64], 8'hFF);
+                    3'd2: ddram_write(base_addr + 29'h14, cram2_snap[191:128], 8'hFF);
+                    3'd3: ddram_write(base_addr + 29'h15, cram2_snap[255:192], 8'hFF);
+                    3'd4: ddram_write(base_addr + 29'h16, cram2_snap[319:256], 8'hFF);
+                    3'd5: ddram_write(base_addr + 29'h17, cram2_snap[383:320], 8'hFF);
+                    default: ;
+                endcase
+                if (cram_idx == 3'd5) begin
+                    cram_idx <= 0;
+                    state    <= ST_SAVE_PSG2;
+                end else begin
+                    cram_idx <= cram_idx + 3'd1;
+                end
+            end
+        end
+
+        ST_SAVE_PSG2: begin
+            if (!DDRAM_BUSY) begin
+                ddram_write(base_addr + 29'h18, {8'h0, psg2_snap}, 8'h7F);
+                // Now start VRAM1 DMA from VDP1's active se_bank half
+                vram_save_addr <= {mapper_snap[7], 14'b0};
                 vram_byte_cnt  <= 0;
                 vram_word_buf  <= 0;
                 vram_pipe      <= 0;
                 vram_en        <= 1;
-                vram_A         <= 0;
+                vram_A         <= {mapper_snap[7], 14'b0};
                 word_cnt       <= 0;
                 vram_d_latched <= 0;
                 state          <= ST_SAVE_VRAM;
@@ -486,7 +729,7 @@ always @(posedge clk or negedge reset_n) begin
             if (vram_pipe < 3'd2) begin
                 // Prime the pipeline: advance address each cycle
                 vram_pipe <= vram_pipe + 3'd1;
-                if (vram_pipe >= 1 && vram_save_addr < 15'd16384)
+                if (vram_pipe >= 1 && vram_save_addr[13:0] != 14'h3FFF)
                     vram_A <= vram_save_addr + 15'd1;
             end else begin
                 // Stall entire pipeline at 8-byte word boundary if DDRAM is busy.
@@ -502,26 +745,39 @@ always @(posedge clk or negedge reset_n) begin
                                       vram_word_buf[63:8]};
                     vram_byte_cnt <= vram_byte_cnt + 3'd1;
                     if (vram_byte_cnt == 7) begin
-                        ddram_write(base_addr + 29'h101 + {18'd0, word_cnt},
+                        ddram_write(base_addr + 29'h101 + {17'd0, word_cnt},
                                     {vram_d_latched ? vram_d_latch : vram_D,
                                      vram_word_buf[63:8]}, 8'hFF);
-                        word_cnt <= word_cnt + 11'd1;
+                        word_cnt <= word_cnt + 12'd1;
                     end
                     // Advance address pipeline
-                    if (vram_save_addr < 15'd16383) begin
+                    if (vram_save_addr[13:0] < 14'h3FFF) begin
                         vram_save_addr <= vram_save_addr + 15'd1;
                         vram_A         <= vram_save_addr + 15'd2;
                     end else if (vram_byte_cnt == 7) begin
-                        vram_en <= 0;
-                        // Start WRAM DMA
-                        wram_save_addr <= 0;
-                        wram_byte_cnt  <= 0;
-                        wram_word_buf  <= 0;
-                        wram_pipe      <= 0;
-                        wram_A         <= 0;
-                        word_cnt       <= 0;
-                        wram_d_latched <= 0;
-                        state          <= ST_SAVE_WRAM;
+                        if (systeme) begin
+                            // System E: save VDP1 passive bank before WRAM
+                            vram_save_addr <= {~mapper_snap[7], 14'b0};
+                            vram_byte_cnt  <= 0;
+                            vram_word_buf  <= 0;
+                            vram_pipe      <= 0;
+                            vram_A         <= {~mapper_snap[7], 14'b0};
+                            word_cnt       <= 0;
+                            vram_d_latched <= 0;
+                            state          <= ST_SAVE_VRAM1_PASSIVE;
+                            vram_en        <= 1;
+                        end else begin
+                            vram_en <= 0;
+                            // Start WRAM DMA
+                            wram_save_addr <= 0;
+                            wram_byte_cnt  <= 0;
+                            wram_word_buf  <= 0;
+                            wram_pipe      <= 0;
+                            wram_A         <= 0;
+                            word_cnt       <= 0;
+                            wram_d_latched <= 0;
+                            state          <= ST_SAVE_WRAM;
+                        end
                     end
                 end else begin
                     // DDRAM busy at boundary: latch byte-7 on the first
@@ -534,10 +790,57 @@ always @(posedge clk or negedge reset_n) begin
             end
         end
 
+        ST_SAVE_VRAM1_PASSIVE: begin
+            // System E: DMA VDP1 passive bank (16 KB) to DDRAM at passive1_base(cur_slot).
+            // Reuses vram_save_addr / vram_byte_cnt / vram_word_buf / vram_pipe / vram_d_latched.
+            // Entry: vram_save_addr = {~mapper_snap[7], 14'b0}, vram_en = 1, pipe/cnt reset.
+            vram_en <= 1;
+            if (vram_pipe < 3'd2) begin
+                vram_pipe <= vram_pipe + 3'd1;
+                if (vram_pipe >= 1 && vram_save_addr[13:0] != 14'h3FFF)
+                    vram_A <= vram_save_addr + 15'd1;
+            end else begin
+                if (vram_byte_cnt < 7 || !DDRAM_BUSY) begin
+                    vram_d_latched <= 0;
+                    vram_word_buf <= {(vram_byte_cnt == 7 && vram_d_latched) ? vram_d_latch : vram_D,
+                                      vram_word_buf[63:8]};
+                    vram_byte_cnt <= vram_byte_cnt + 3'd1;
+                    if (vram_byte_cnt == 7) begin
+                        ddram_write(base_addr + 29'h1901 + {17'd0, word_cnt},
+                                    {vram_d_latched ? vram_d_latch : vram_D,
+                                     vram_word_buf[63:8]}, 8'hFF);
+                        word_cnt <= word_cnt + 12'd1;
+                    end
+                    if (vram_save_addr[13:0] < 14'h3FFF) begin
+                        vram_save_addr <= vram_save_addr + 15'd1;
+                        vram_A         <= vram_save_addr + 15'd2;
+                    end else if (vram_byte_cnt == 7) begin
+                        vram_en <= 0;
+                        // Continue to WRAM save
+                        wram_save_addr <= 0;
+                        wram_byte_cnt  <= 0;
+                        wram_word_buf  <= 0;
+                        wram_pipe      <= 0;
+                        wram_A         <= 0;
+                        word_cnt       <= 0;
+                        wram_d_latched <= 0;
+                        state          <= ST_SAVE_WRAM;
+                    end
+                end else begin
+                    if (!vram_d_latched) begin
+                        vram_d_latch   <= vram_D;
+                        vram_d_latched <= 1;
+                    end
+                end
+            end
+        end
+
         ST_SAVE_WRAM: begin
+            // System E has 16KB RAM (0x0000-0x3FFF); SMS has 8KB (0xC000-0xDFFF).
+            // For System E we reuse the combined WRAM+NVRAM region (0x901-0x1100).
             if (wram_pipe < 2'd2) begin
                 wram_pipe <= wram_pipe + 2'd1;
-                if (wram_pipe >= 1 && wram_save_addr < 14'd8191)
+                if (wram_pipe >= 1 && wram_save_addr < (systeme ? 14'd16383 : 14'd8191))
                     wram_A <= wram_save_addr + 14'd1;
             end else begin
                 // Stall at 8-byte boundary if DDRAM is busy (same pattern as VRAM)
@@ -547,17 +850,28 @@ always @(posedge clk or negedge reset_n) begin
                                       wram_word_buf[63:8]};
                     wram_byte_cnt <= wram_byte_cnt + 3'd1;
                     if (wram_byte_cnt == 7) begin
-                        ddram_write(base_addr + 29'h901 + {18'd0, word_cnt},
+                        ddram_write(base_addr + 29'h901 + {17'd0, word_cnt},
                                     {wram_d_latched ? wram_d_latch : wram_D,
                                      wram_word_buf[63:8]}, 8'hFF);
-                        word_cnt <= word_cnt + 11'd1;
+                        word_cnt <= word_cnt + 12'd1;
                     end
-                    if (wram_save_addr < 14'd8191) begin
+                    if (wram_save_addr < (systeme ? 14'd16383 : 14'd8191)) begin
                         wram_save_addr <= wram_save_addr + 14'd1;
                         wram_A         <= wram_save_addr + 14'd2;
                     end else if (wram_byte_cnt == 7) begin
-                        if (mapper_snap[48]) begin
-                            // Dahjee A: save 8KB nvram (expansion RAM at $2000-$3FFF)
+                        if (systeme) begin
+                            // System E: save second VRAM (16KB) at 0x1101, from VDP2's active se_bank
+                            vram_save_addr <= {mapper_snap[6], 14'b0};
+                            vram_byte_cnt  <= 0;
+                            vram_word_buf  <= 0;
+                            vram_pipe      <= 0;
+                            vram2_en       <= 1;
+                            vram2_A        <= {mapper_snap[6], 14'b0};
+                            word_cnt       <= 0;
+                            vram_d_latched <= 0;
+                            state          <= ST_SAVE_VRAM2;
+                        end else if (has_nvram) begin
+                            // Save NVRAM (up to 32KB)
                             nvram_save_addr <= 0;
                             nvram_byte_cnt  <= 0;
                             nvram_word_buf  <= 0;
@@ -582,8 +896,8 @@ always @(posedge clk or negedge reset_n) begin
         ST_SAVE_NVRAM: begin
             if (nvram_pipe < 2'd2) begin
                 nvram_pipe <= nvram_pipe + 2'd1;
-                if (nvram_pipe >= 1 && nvram_save_addr < 13'd8191)
-                    nvram_A <= nvram_save_addr + 13'd1;
+                if (nvram_pipe >= 1 && nvram_save_addr < nvram_size_minus_1)
+                    nvram_A <= nvram_save_addr + 15'd1;
             end else begin
                 // Stall at 8-byte boundary if DDRAM is busy (same pattern as VRAM/WRAM)
                 if (nvram_byte_cnt < 7 || !DDRAM_BUSY) begin
@@ -592,14 +906,14 @@ always @(posedge clk or negedge reset_n) begin
                                        nvram_word_buf[63:8]};
                     nvram_byte_cnt <= nvram_byte_cnt + 3'd1;
                     if (nvram_byte_cnt == 7) begin
-                        ddram_write(base_addr + 29'h0D01 + {18'd0, word_cnt},
+                        ddram_write(base_addr + 29'h0D01 + {17'd0, word_cnt},
                                     {nvram_d_latched ? nvram_d_latch : nvram_D,
                                      nvram_word_buf[63:8]}, 8'hFF);
-                        word_cnt <= word_cnt + 11'd1;
+                        word_cnt <= word_cnt + 12'd1;
                     end
-                    if (nvram_save_addr < 13'd8191) begin
-                        nvram_save_addr <= nvram_save_addr + 13'd1;
-                        nvram_A         <= nvram_save_addr + 13'd2;
+                    if (nvram_save_addr < nvram_size_minus_1) begin
+                        nvram_save_addr <= nvram_save_addr + 15'd1;
+                        nvram_A         <= nvram_save_addr + 15'd2;
                     end else if (nvram_byte_cnt == 7) begin
                         state <= ST_SAVE_DONE;
                     end
@@ -612,21 +926,117 @@ always @(posedge clk or negedge reset_n) begin
             end
         end
 
+        ST_SAVE_VRAM2: begin
+            // System E: DMA VRAM2 (16KB) to DDRAM at base + 0x1101
+            // Reuse vram_save_addr / vram_byte_cnt / vram_word_buf / vram_d_latched,
+            // but drive vram2_* instead of vram_*.
+            vram2_en <= 1;
+            if (vram_pipe < 3'd2) begin
+                vram_pipe <= vram_pipe + 3'd1;
+                if (vram_pipe >= 1 && vram_save_addr[13:0] != 14'h3FFF)
+                    vram2_A <= vram_save_addr + 15'd1;
+            end else begin
+                if (vram_byte_cnt < 7 || !DDRAM_BUSY) begin
+                    vram_d_latched <= 0;
+                    vram_word_buf <= {(vram_byte_cnt == 7 && vram_d_latched) ? vram_d_latch : vram2_D,
+                                      vram_word_buf[63:8]};
+                    vram_byte_cnt <= vram_byte_cnt + 3'd1;
+                    if (vram_byte_cnt == 7) begin
+                        ddram_write(base_addr + 29'h1101 + {17'd0, word_cnt},
+                                    {vram_d_latched ? vram_d_latch : vram2_D,
+                                     vram_word_buf[63:8]}, 8'hFF);
+                        word_cnt <= word_cnt + 12'd1;
+                    end
+                    if (vram_save_addr[13:0] < 14'h3FFF) begin
+                        vram_save_addr <= vram_save_addr + 15'd1;
+                        vram2_A        <= vram_save_addr + 15'd2;
+                    end else if (vram_byte_cnt == 7) begin
+                        // Save VDP2 passive bank before ending (ST_SAVE_VRAM2 is System E only)
+                        vram_save_addr <= {~mapper_snap[6], 14'b0};
+                        vram_byte_cnt  <= 0;
+                        vram_word_buf  <= 0;
+                        vram_pipe      <= 0;
+                        vram2_A        <= {~mapper_snap[6], 14'b0};
+                        word_cnt       <= 0;
+                        vram_d_latched <= 0;
+                        state          <= ST_SAVE_VRAM2_PASSIVE;
+                        // vram2_en stays 1 for the passive-save state
+                    end
+                end else begin
+                    if (!vram_d_latched) begin
+                        vram_d_latch   <= vram2_D;
+                        vram_d_latched <= 1;
+                    end
+                end
+            end
+        end
+
+        ST_SAVE_VRAM2_PASSIVE: begin
+            // System E: DMA VDP2 passive bank (16 KB) to DDRAM at passive2_base(cur_slot).
+            // Entry: vram_save_addr = {~mapper_snap[6], 14'b0}, vram2_en = 1, pipe/cnt reset.
+            vram2_en <= 1;
+            if (vram_pipe < 3'd2) begin
+                vram_pipe <= vram_pipe + 3'd1;
+                if (vram_pipe >= 1 && vram_save_addr[13:0] != 14'h3FFF)
+                    vram2_A <= vram_save_addr + 15'd1;
+            end else begin
+                if (vram_byte_cnt < 7 || !DDRAM_BUSY) begin
+                    vram_d_latched <= 0;
+                    vram_word_buf <= {(vram_byte_cnt == 7 && vram_d_latched) ? vram_d_latch : vram2_D,
+                                      vram_word_buf[63:8]};
+                    vram_byte_cnt <= vram_byte_cnt + 3'd1;
+                    if (vram_byte_cnt == 7) begin
+                        ddram_write(base_addr + 29'h2101 + {17'd0, word_cnt},
+                                    {vram_d_latched ? vram_d_latch : vram2_D,
+                                     vram_word_buf[63:8]}, 8'hFF);
+                        word_cnt <= word_cnt + 12'd1;
+                    end
+                    if (vram_save_addr[13:0] < 14'h3FFF) begin
+                        vram_save_addr <= vram_save_addr + 15'd1;
+                        vram2_A        <= vram_save_addr + 15'd2;
+                    end else if (vram_byte_cnt == 7) begin
+                        vram2_en <= 0;
+                        state    <= ST_SAVE_DONE;
+                    end
+                end else begin
+                    if (!vram_d_latched) begin
+                        vram_d_latch   <= vram2_D;
+                        vram_d_latched <= 1;
+                    end
+                end
+            end
+        end
+
         ST_SAVE_DONE: begin
             // Write MiSTer framework control word at slot base (word 0).
             // [31:0]  = change_det: must change on every save to trigger firmware write to /savestates/
             // [63:32] = size in 32-bit words = (slot_size_bytes - 8) / 4
-            //           slot = 64KB = 65536 bytes; minus 8-byte control word = 65528 bytes → 16382 words
+            //           slot = 96KB = 98304 bytes; minus 8-byte control word = 98296 bytes → 24574 words
             if (cur_bios_mode) begin
                 // BIOS states live in their own DDRAM region (bios_slot_base);
                 // no change_det write → ARM never saves them to disk, so they
                 // cannot contaminate the last-loaded game's .ss file.
-                state <= ST_UNFREEZE;
+                freeze_drain_cnt <= 0;
+                state <= ST_SAVE_SETTLE;
             end else if (!DDRAM_BUSY) begin
-                ddram_write(base_addr + 29'd0, {32'd16382, ss_change_det}, 8'hFF);
+                ddram_write(base_addr + 29'd0, {32'd24574, ss_change_det}, 8'hFF);
                 ss_change_det <= ss_change_det + 32'd1;
-                state <= ST_UNFREEZE;
+                freeze_drain_cnt <= 0;
+                state <= ST_SAVE_SETTLE;
             end
+        end
+
+        ST_SAVE_SETTLE: begin
+            // Wait for 32 consecutive idle clocks after the last save write.
+            // This avoids immediate load seeing partially drained write queues.
+            if (DDRAM_BUSY)
+                freeze_drain_cnt <= 0;
+            else if (freeze_drain_cnt == 6'd31) begin
+                unfreeze_cnt <= 8'd0;
+                align_timeout <= 22'd0;
+                state <= ST_UNFREEZE;
+            end else
+                freeze_drain_cnt <= freeze_drain_cnt + 6'd1;
         end
 
         // ===============================================================
@@ -635,7 +1045,7 @@ always @(posedge clk or negedge reset_n) begin
 
         ST_LOAD_HDR_RD: begin
             if (!DDRAM_BUSY) begin
-                ddram_read(base_addr + 29'd1);
+                ddram_read(base_addr + 29'd0);
                 state <= ST_LOAD_HDR_WT;
             end
         end
@@ -643,13 +1053,29 @@ always @(posedge clk or negedge reset_n) begin
         ST_LOAD_HDR_WT: begin
             if (DDRAM_DOUT_READY && dout_expected) begin
                 dout_expected <= 0;
-                if (DDRAM_DOUT[31:0] == cur_magic) begin
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                is_old_format <= (dout_latch[63:32] == 32'h4000);
+                ddram_read(base_addr + 29'd1);
+                state <= ST_LOAD_HDR_WT2;
+            end
+        end
+
+        ST_LOAD_HDR_WT2: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                if (dout_latch[31:0] == cur_magic && dout_latch[63:32] == cur_game_id) begin
                     // Read Z80 words
                     ddram_read(base_addr + 29'd2);
                     cpu_idx <= 0;
                     state   <= ST_LOAD_CPU0;
                 end else begin
                     // Invalid magic: abort
+                    unfreeze_cnt <= 8'd0;
+                    align_timeout <= 22'd0;
+                    is_old_format <= 1; // bypass coordinate alignment
                     state <= ST_UNFREEZE;
                 end
             end
@@ -658,11 +1084,23 @@ always @(posedge clk or negedge reset_n) begin
         ST_LOAD_CPU0: begin
             if (DDRAM_DOUT_READY && dout_expected) begin
                 dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
                 case (cpu_idx)
-                    3'd0: begin z80_dir[63:0]    <= DDRAM_DOUT; ddram_read(base_addr + 29'd3); end
-                    3'd1: begin z80_dir[127:64]  <= DDRAM_DOUT; ddram_read(base_addr + 29'd4); end
-                    3'd2: begin z80_dir[191:128] <= DDRAM_DOUT; ddram_read(base_addr + 29'd5); end
-                    3'd3: begin z80_dir[211:192] <= DDRAM_DOUT[19:0]; ddram_read(base_addr + 29'd6); end
+                    3'd0: begin z80_snap[63:0]    <= dout_latch; ddram_read(base_addr + 29'd3); end
+                    3'd1: begin z80_snap[127:64]  <= dout_latch; ddram_read(base_addr + 29'd4); end
+                    3'd2: begin z80_snap[191:128] <= dout_latch; ddram_read(base_addr + 29'd5); end
+                    3'd3: begin
+                        if (is_old_format) begin
+                            z80_snap[211:192] <= dout_latch[19:0];
+                            z80_snap[227:212] <= 16'd0;
+                            z80_snap[228]     <= 1'b0;
+                            z80_snap[229]     <= 1'b0; // Halt_FF default on old format
+                        end else begin
+                            z80_snap[229:192] <= dout_latch[37:0];
+                        end
+                        ddram_read(base_addr + 29'd6);
+                    end
                 endcase
                 if (cpu_idx == 3) begin
                     vdp_idx <= 0;
@@ -675,9 +1113,11 @@ always @(posedge clk or negedge reset_n) begin
         ST_LOAD_VDP0: begin
             if (DDRAM_DOUT_READY && dout_expected) begin
                 dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
                 case (vdp_idx[0])
-                    1'b0: begin vdp_regs_in[63:0]   <= DDRAM_DOUT; ddram_read(base_addr + 29'd7); end
-                    1'b1: begin vdp_regs_in[127:64]  <= DDRAM_DOUT; ddram_read(base_addr + 29'd8); end
+                    1'b0: begin vdp_snap[63:0]   <= dout_latch; ddram_read(base_addr + 29'd7); end
+                    1'b1: begin vdp_snap[127:64]  <= dout_latch; ddram_read(base_addr + 29'd8); end
                 endcase
                 if (vdp_idx[0]) begin
                     cram_idx <= 0;
@@ -693,13 +1133,15 @@ always @(posedge clk or negedge reset_n) begin
             // Phase 2: write entries (use cram_entry)
             if (DDRAM_DOUT_READY && dout_expected) begin
                 dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
                 case (cram_idx)
-                    3'd0: begin cram_snap[63:0]    <= DDRAM_DOUT; ddram_read(base_addr + 29'd9);  end
-                    3'd1: begin cram_snap[127:64]  <= DDRAM_DOUT; ddram_read(base_addr + 29'd10); end
-                    3'd2: begin cram_snap[191:128] <= DDRAM_DOUT; ddram_read(base_addr + 29'd11); end
-                    3'd3: begin cram_snap[255:192] <= DDRAM_DOUT; ddram_read(base_addr + 29'd12); end
-                    3'd4: begin cram_snap[319:256] <= DDRAM_DOUT; ddram_read(base_addr + 29'd13); end
-                    3'd5: begin cram_snap[383:320] <= DDRAM_DOUT; ddram_read(base_addr + 29'd14); end
+                    3'd0: begin cram_snap[63:0]    <= dout_latch; ddram_read(base_addr + 29'd9);  end
+                    3'd1: begin cram_snap[127:64]  <= dout_latch; ddram_read(base_addr + 29'd10); end
+                    3'd2: begin cram_snap[191:128] <= dout_latch; ddram_read(base_addr + 29'd11); end
+                    3'd3: begin cram_snap[255:192] <= dout_latch; ddram_read(base_addr + 29'd12); end
+                    3'd4: begin cram_snap[319:256] <= dout_latch; ddram_read(base_addr + 29'd13); end
+                    3'd5: begin cram_snap[383:320] <= dout_latch; ddram_read(base_addr + 29'd14); end
                     default: ;
                 endcase
                 if (cram_idx == 5) begin
@@ -715,7 +1157,9 @@ always @(posedge clk or negedge reset_n) begin
         ST_LOAD_PSG: begin
             if (DDRAM_DOUT_READY && dout_expected) begin
                 dout_expected <= 0;
-                psg_snap <= DDRAM_DOUT[55:0];
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                psg_snap <= dout_latch[55:0];
                 ddram_read(base_addr + 29'd15);
                 state    <= ST_LOAD_MAPPER;
             end
@@ -723,11 +1167,113 @@ always @(posedge clk or negedge reset_n) begin
 
         ST_LOAD_MAPPER: begin
             if (DDRAM_DOUT_READY && dout_expected) begin
-                dout_expected    <= 0;
-                mapper_snap      <= DDRAM_DOUT;
-                // Restore memory (VRAM/WRAM) BEFORE applying registers so the VDP never
-                // renders with new register settings against old VRAM content.
-                vram_load_addr   <= 0;
+                dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                mapper_snap      <= dout_latch;
+                if (is_old_format) begin
+                    vram_load_addr   <= 0;
+                    vram_byte_cnt    <= 0;
+                    vram_load_active <= 0;
+                    word_cnt         <= 0;
+                    ddram_read(base_addr + 29'h101);
+                    state <= ST_LOAD_VRAM;
+                end else begin
+                    ddram_read(base_addr + 29'h019);
+                    state            <= ST_LOAD_IO;
+                end
+            end
+        end
+
+        ST_LOAD_IO: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                io_snap          <= dout_latch[31:0];
+                ddram_read(base_addr + 29'h01a);
+                state            <= ST_LOAD_VIDEO;
+            end
+        end
+
+        ST_LOAD_VIDEO: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                video_snap       <= dout_latch[21:0];
+                if (systeme) begin
+                    // System E: read VDP2/CRAM2/PSG2 before restoring VRAM
+                    ddram_read(base_addr + 29'h10);
+                    cram_idx <= 0;
+                    state    <= ST_LOAD_VDP2REG;
+                end else begin
+                    // Restore memory (VRAM/WRAM) BEFORE applying registers so the VDP never
+                    // renders with new register settings against old VRAM content.
+                    vram_load_addr   <= 0;
+                    vram_byte_cnt    <= 0;
+                    vram_load_active <= 0;
+                    word_cnt         <= 0;
+                    ddram_read(base_addr + 29'h101);
+                    state <= ST_LOAD_VRAM;
+                end
+            end
+        end
+
+        ST_LOAD_VDP2REG: begin
+            // Read 2 × 64-bit words for VDP2 regs
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                case (cram_idx)
+                    3'd0: begin
+                        vdp2_snap[63:0] <= dout_latch;
+                        cram_idx <= 3'd1;
+                        ddram_read(base_addr + 29'h11);
+                    end
+                    3'd1: begin
+                        vdp2_snap[127:64] <= dout_latch;
+                        cram_idx <= 3'd0;
+                        ddram_read(base_addr + 29'h12);
+                        state <= ST_LOAD_CRAM2;
+                    end
+                    default: ;
+                endcase
+            end
+        end
+
+        ST_LOAD_CRAM2: begin
+            // Read 6 × 64-bit words for CRAM2
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                case (cram_idx)
+                    3'd0: begin cram2_snap[ 63:  0] <= dout_latch; cram_idx <= 3'd1; ddram_read(base_addr + 29'h13); end
+                    3'd1: begin cram2_snap[127: 64] <= dout_latch; cram_idx <= 3'd2; ddram_read(base_addr + 29'h14); end
+                    3'd2: begin cram2_snap[191:128] <= dout_latch; cram_idx <= 3'd3; ddram_read(base_addr + 29'h15); end
+                    3'd3: begin cram2_snap[255:192] <= dout_latch; cram_idx <= 3'd4; ddram_read(base_addr + 29'h16); end
+                    3'd4: begin cram2_snap[319:256] <= dout_latch; cram_idx <= 3'd5; ddram_read(base_addr + 29'h17); end
+                    3'd5: begin
+                        cram2_snap[383:320] <= dout_latch;
+                        cram_idx <= 3'd0;
+                        ddram_read(base_addr + 29'h18);
+                        state <= ST_LOAD_PSG2;
+                    end
+                    default: ;
+                endcase
+            end
+        end
+
+        ST_LOAD_PSG2: begin
+            if (DDRAM_DOUT_READY && dout_expected) begin
+                dout_expected <= 0;
+                dout_latch    <= DDRAM_DOUT;
+            end else if (!dout_expected && !DDRAM_BUSY) begin
+                psg2_snap <= dout_latch[55:0];
+                // Now restore VRAM1 to VDP1's active se_bank half
+                vram_load_addr   <= {mapper_snap[7], 14'b0};
                 vram_byte_cnt    <= 0;
                 vram_load_active <= 0;
                 word_cnt         <= 0;
@@ -747,25 +1293,42 @@ always @(posedge clk or negedge reset_n) begin
                 end
             end else begin
                 // Write one byte per clock cycle from the latched word
-                vram_WE         <= 1;
-                vram_WA         <= vram_load_addr;
-                vram_WD         <= dout_latch[8*vram_byte_cnt +: 8];
-                vram_load_addr  <= vram_load_addr + 15'd1;
-                vram_byte_cnt   <= vram_byte_cnt + 3'd1; // 3-bit: wraps 7→0
-                if (vram_byte_cnt == 3'd7) begin
-                    // Last byte - deactivate and fetch next word
-                    vram_load_active <= 0;
-                    if (word_cnt < 11'd2047) begin
-                        word_cnt <= word_cnt + 11'd1;
-                        ddram_read(base_addr + 29'h101 + {18'd0, word_cnt + 11'd1});
-                    end else begin
-                        // VRAM done → WRAM
-                        wram_load_addr   <= 0;
-                        wram_byte_cnt    <= 0;
-                        wram_load_active <= 0;
-                        word_cnt         <= 0;
-                        ddram_read(base_addr + 29'h901);
-                        state <= ST_LOAD_WRAM;
+                if (vram_byte_cnt < 7) begin
+                    vram_WE         <= 1;
+                    vram_WA         <= vram_load_addr;
+                    vram_WD         <= dout_latch[8*vram_byte_cnt +: 8];
+                    vram_load_addr  <= vram_load_addr + 15'd1;
+                    vram_byte_cnt   <= vram_byte_cnt + 3'd1;
+                end else begin // vram_byte_cnt == 7
+                    if (!DDRAM_BUSY) begin
+                        vram_WE         <= 1;
+                        vram_WA         <= vram_load_addr;
+                        vram_WD         <= dout_latch[8*7 +: 8];
+                        vram_load_addr  <= vram_load_addr + 15'd1;
+                        vram_load_active <= 0;
+                        vram_byte_cnt   <= 0;
+                        if (word_cnt < 12'd2047) begin
+                            word_cnt <= word_cnt + 12'd1;
+                            ddram_read(base_addr + 29'h101 + {17'd0, word_cnt + 12'd1});
+                        end else begin
+                            if (systeme) begin
+                                // System E: restore VDP1 passive bank from inline slot data.
+                                vram_load_addr   <= {~mapper_snap[7], 14'b0};
+                                vram_byte_cnt    <= 0;
+                                vram_load_active <= 0;
+                                word_cnt         <= 0;
+                                ddram_read(base_addr + 29'h1901);
+                                state <= ST_LOAD_VRAM1_PASSIVE;
+                            end else begin
+                                // VRAM done → WRAM
+                                wram_load_addr   <= 0;
+                                wram_byte_cnt    <= 0;
+                                wram_load_active <= 0;
+                                word_cnt         <= 0;
+                                ddram_read(base_addr + 29'h901);
+                                state <= ST_LOAD_WRAM;
+                            end
+                        end
                     end
                 end
             end
@@ -780,29 +1343,37 @@ always @(posedge clk or negedge reset_n) begin
                     wram_load_active <= 1;
                 end
             end else begin
-                wram_WE         <= 1;
-                wram_WA         <= wram_load_addr;
-                wram_WD         <= dout_latch[8*wram_byte_cnt +: 8];
-                wram_load_addr  <= wram_load_addr + 14'd1;
-                wram_byte_cnt   <= wram_byte_cnt + 3'd1;
-                if (wram_byte_cnt == 3'd7) begin
-                    wram_load_active <= 0;
-                    if (word_cnt < 11'd1023) begin
-                        word_cnt <= word_cnt + 11'd1;
-                        ddram_read(base_addr + 29'h901 + {18'd0, word_cnt + 11'd1});
-                    end else begin
-                        if (mapper_snap[48]) begin
-                            // Dahjee A: restore 8KB nvram
-                            nvram_load_addr   <= 0;
-                            nvram_byte_cnt    <= 0;
-                            nvram_load_active <= 0;
-                            word_cnt          <= 0;
-                            ddram_read(base_addr + 29'h0D01);
-                            state <= ST_LOAD_NVRAM;
+                if (wram_byte_cnt < 7) begin
+                    wram_WE         <= 1;
+                    wram_WA         <= wram_load_addr;
+                    wram_WD         <= dout_latch[8*wram_byte_cnt +: 8];
+                    wram_load_addr  <= wram_load_addr + 14'd1;
+                    wram_byte_cnt   <= wram_byte_cnt + 3'd1;
+                end else begin // wram_byte_cnt == 7
+                    if (!DDRAM_BUSY) begin
+                        wram_WE         <= 1;
+                        wram_WA         <= wram_load_addr;
+                        wram_WD         <= dout_latch[8*7 +: 8];
+                        wram_load_addr  <= wram_load_addr + 14'd1;
+                        wram_load_active <= 0;
+                        wram_byte_cnt   <= 0;
+                        if (word_cnt < (systeme ? 12'd2047 : 12'd1023)) begin
+                            word_cnt <= word_cnt + 12'd1;
+                            ddram_read(base_addr + 29'h901 + {17'd0, word_cnt + 12'd1});
                         end else begin
-                            // All memory restored; restore mapper first, then core.
-                            state      <= ST_WAIT_RESTORE_BOUNDARY;
-                            cram_entry <= 0;
+                            if (systeme) begin
+                                // System E: restore VRAM2 to VDP2's active se_bank half
+                                vram_load_addr   <= {mapper_snap[6], 14'b0};
+                                vram_byte_cnt    <= 0;
+                                vram_load_active <= 0;
+                                word_cnt         <= 0;
+                                ddram_read(base_addr + 29'h1101);
+                                state <= ST_LOAD_VRAM2;
+                            end else begin
+                                // WRAM done, transition to mapper restore first
+                                state      <= ST_WAIT_RESTORE_BOUNDARY;
+                                cram_entry <= 0;
+                            end
                         end
                     end
                 end
@@ -818,59 +1389,214 @@ always @(posedge clk or negedge reset_n) begin
                     nvram_load_active <= 1;
                 end
             end else begin
-                nvram_WE        <= 1;
-                nvram_WA        <= nvram_load_addr;
-                nvram_WD        <= dout_latch[8*nvram_byte_cnt +: 8];
-                nvram_load_addr <= nvram_load_addr + 13'd1;
-                nvram_byte_cnt  <= nvram_byte_cnt + 3'd1;
-                if (nvram_byte_cnt == 3'd7) begin
-                    nvram_load_active <= 0;
-                    if (word_cnt < 11'd1023) begin
-                        word_cnt <= word_cnt + 11'd1;
-                        ddram_read(base_addr + 29'h0D01 + {18'd0, word_cnt + 11'd1});
-                    end else begin
-                        // All memory restored; restore mapper first, then core.
-                        state      <= ST_WAIT_RESTORE_BOUNDARY;
-                        cram_entry <= 0;
+                if (nvram_byte_cnt < 7) begin
+                    nvram_WE        <= 1;
+                    nvram_WA        <= nvram_load_addr;
+                    nvram_WD        <= dout_latch[8*nvram_byte_cnt +: 8];
+                    nvram_load_addr <= nvram_load_addr + 15'd1;
+                    nvram_byte_cnt  <= nvram_byte_cnt + 3'd1;
+                end else begin // nvram_byte_cnt == 7
+                    if (!DDRAM_BUSY) begin
+                        nvram_WE        <= 1;
+                        nvram_WA        <= nvram_load_addr;
+                        nvram_WD        <= dout_latch[8*7 +: 8];
+                        nvram_load_addr <= nvram_load_addr + 15'd1;
+                        nvram_load_active <= 0;
+                        nvram_byte_cnt  <= 0;
+                        if (word_cnt < (nvram_size_minus_1 >> 3)) begin
+                            word_cnt <= word_cnt + 12'd1;
+                            ddram_read(base_addr + 29'h0D01 + {17'd0, word_cnt + 12'd1});
+                        end else begin
+                            state      <= ST_LOAD_RESTORE;
+                            cram_entry <= 0;
+                        end
                     end
                 end
             end
         end
 
+        ST_LOAD_VRAM2: begin
+            // System E: DMA DDRAM 0x1101-0x1900 → VRAM2 (16KB)
+            // Reuses vram_load_addr / vram_byte_cnt / vram_load_active / dout_latch
+            if (!vram_load_active) begin
+                if (DDRAM_DOUT_READY && dout_expected) begin
+                    dout_expected    <= 0;
+                    dout_latch       <= DDRAM_DOUT;
+                    vram_byte_cnt    <= 0;
+                    vram_load_active <= 1;
+                end
+            end else begin
+                if (vram_byte_cnt < 7) begin
+                    vram2_WE         <= 1;
+                    vram2_WA         <= vram_load_addr;
+                    vram2_WD         <= dout_latch[8*vram_byte_cnt +: 8];
+                    vram_load_addr   <= vram_load_addr + 15'd1;
+                    vram_byte_cnt    <= vram_byte_cnt + 3'd1;
+                end else begin // vram_byte_cnt == 7
+                    if (!DDRAM_BUSY) begin
+                        vram2_WE         <= 1;
+                        vram2_WA         <= vram_load_addr;
+                        vram2_WD         <= dout_latch[8*7 +: 8];
+                        vram_load_addr   <= vram_load_addr + 15'd1;
+                        vram_load_active <= 0;
+                        vram_byte_cnt    <= 0;
+                        if (word_cnt < 12'd2047) begin
+                            word_cnt <= word_cnt + 12'd1;
+                            ddram_read(base_addr + 29'h1101 + {17'd0, word_cnt + 12'd1});
+                        end else begin
+                            // Restore VDP2 passive bank from inline slot area.
+                            vram_load_addr   <= {~mapper_snap[6], 14'b0};
+                            vram_byte_cnt    <= 0;
+                            vram_load_active <= 0;
+                            word_cnt         <= 0;
+                            ddram_read(base_addr + 29'h2101);
+                            state <= ST_LOAD_VRAM2_PASSIVE;
+                        end
+                    end
+                end
+            end
+        end
+
+        ST_LOAD_VRAM1_PASSIVE: begin
+            // System E: restore VDP1 passive bank from inline slot area (base + 0x1901).
+            if (!vram_load_active) begin
+                if (DDRAM_DOUT_READY && dout_expected) begin
+                    dout_expected    <= 0;
+                    dout_latch       <= DDRAM_DOUT;
+                    vram_byte_cnt    <= 0;
+                    vram_load_active <= 1;
+                end
+            end else begin
+                if (vram_byte_cnt < 7) begin
+                    vram_WE         <= 1;
+                    vram_WA         <= vram_load_addr;
+                    vram_WD         <= dout_latch[8*vram_byte_cnt +: 8];
+                    vram_load_addr  <= vram_load_addr + 15'd1;
+                    vram_byte_cnt   <= vram_byte_cnt + 3'd1;
+                end else begin // vram_byte_cnt == 7
+                    if (!DDRAM_BUSY) begin
+                        vram_WE         <= 1;
+                        vram_WA         <= vram_load_addr;
+                        vram_WD         <= dout_latch[8*7 +: 8];
+                        vram_load_addr  <= vram_load_addr + 15'd1;
+                        vram_load_active <= 0;
+                        vram_byte_cnt   <= 0;
+                        if (word_cnt < 12'd2047) begin
+                            word_cnt <= word_cnt + 12'd1;
+                            ddram_read(base_addr + 29'h1901 + {17'd0, word_cnt + 12'd1});
+                        end else begin
+                            wram_load_addr   <= 0;
+                            wram_byte_cnt    <= 0;
+                            wram_load_active <= 0;
+                            word_cnt         <= 0;
+                            ddram_read(base_addr + 29'h901);
+                            state <= ST_LOAD_WRAM;
+                        end
+                    end
+                end
+            end
+        end
+
+        ST_LOAD_VRAM2_PASSIVE: begin
+            // System E: restore VDP2 passive bank from inline slot area (base + 0x2101).
+            if (!vram_load_active) begin
+                if (DDRAM_DOUT_READY && dout_expected) begin
+                    dout_expected    <= 0;
+                    dout_latch       <= DDRAM_DOUT;
+                    vram_byte_cnt    <= 0;
+                    vram_load_active <= 1;
+                end
+            end else begin
+                if (vram_byte_cnt < 7) begin
+                    vram2_WE        <= 1;
+                    vram2_WA        <= vram_load_addr;
+                    vram2_WD        <= dout_latch[8*vram_byte_cnt +: 8];
+                    vram_load_addr  <= vram_load_addr + 15'd1;
+                    vram_byte_cnt   <= vram_byte_cnt + 3'd1;
+                end else begin // vram_byte_cnt == 7
+                    if (!DDRAM_BUSY) begin
+                        vram2_WE        <= 1;
+                        vram2_WA        <= vram_load_addr;
+                        vram2_WD        <= dout_latch[8*7 +: 8];
+                        vram_load_addr  <= vram_load_addr + 15'd1;
+                        vram_load_active <= 0;
+                        vram_byte_cnt   <= 0;
+                        if (word_cnt < 12'd2047) begin
+                            word_cnt <= word_cnt + 12'd1;
+                            ddram_read(base_addr + 29'h2101 + {17'd0, word_cnt + 12'd1});
+                        end else begin
+                            state      <= ST_WAIT_RESTORE_BOUNDARY;
+                            cram_entry <= 0;
+                        end
+                    end
+                end
+            end
+        end
+
+        // ---------------------------------------------------------------
         ST_LOAD_RESTORE: begin
             // VRAM/WRAM and mapper are fully restored. Apply CPU+VDP+PSG state,
             // then stream CRAM while remaining frozen.
             if (cram_entry == 0) begin
                 // CPU is frozen; restore all registers unconditionally.
                 // z80_set loads z80_dir into T80s regardless of CEN.
+                z80_dir      <= z80_snap;
                 z80_set      <= 1;
+                vdp_regs_in  <= vdp_snap;
                 vdp_regs_set <= 1;
                 psg_in       <= psg_snap;
                 psg_set      <= 1;
+                if (!is_old_format) begin
+                    io_in        <= io_snap;
+                    io_set       <= 1;
+                    video_state_in  <= video_snap;
+                    video_state_set <= 1;
+                end
+                // System E: restore second VDP/PSG
+                if (systeme) begin
+                    vdp2_regs_in  <= vdp2_snap;
+                    vdp2_regs_set <= 1;
+                    psg2_in       <= psg2_snap;
+                    psg2_set      <= 1;
+                end
             end
             // Write CRAM entries one per cycle (32 cycles total)
             cram_wr <= 1;
             cram_A  <= cram_entry;
             cram_D  <= cram_snap[12*cram_entry +: 12];
+            // Write CRAM2 in parallel when System E
+            if (systeme) begin
+                cram2_wr <= 1;
+                cram2_A  <= cram_entry;
+                cram2_D  <= cram2_snap[12*cram_entry +: 12];
+            end
             if (cram_entry == 31) begin
-                // All state applied; wait for VBlank before unfreezing
-                state <= ST_WAIT_VBLANK;
+                flush_cnt <= 20'd0;
+                state     <= ST_FLUSH_PIPELINE;
             end else
                 cram_entry <= cram_entry + 5'd1;
         end
 
-        // ---------------------------------------------------------------
         ST_WAIT_VBLANK: begin
-            // Wait for a full VBlank rising → falling edge so we always unfreeze
-            // at y=0 (the very start of active display).  This guarantees:
-            //   • hbl_counter has been reloaded from irq_line_count by the VDP
-            //     during at least one VBlank line at x=486.
-            //   • The game resumes at the cleanest possible frame boundary.
-            // If we enter this state already inside VBlank (vblank=1), vblank_seen
-            // is set immediately, so we unfreeze on the next falling edge (y=0)
-            // rather than exiting right away mid-VBlank.
-            if (vblank)                   vblank_seen <= 1;
-            if (vblank_seen && !vblank)   state <= ST_UNFREEZE;
+            if (!vblank)                  vblank_seen <= 1;
+            if (vblank_seen && vblank) begin
+                flush_cnt <= 20'd0;
+                state     <= ST_FLUSH_PIPELINE;
+            end
+        end
+
+        ST_FLUSH_PIPELINE: begin
+            if (flush_cnt == FLUSH_MAX) begin
+                state <= ST_PRE_UNFREEZE;
+            end else begin
+                flush_cnt <= flush_cnt + 20'd1;
+            end
+        end
+
+        ST_PRE_UNFREEZE: begin
+            unfreeze_cnt <= 8'd0;
+            align_timeout <= 22'd0;
+            state <= ST_UNFREEZE;
         end
 
         // ---------------------------------------------------------------
@@ -878,11 +1604,30 @@ always @(posedge clk or negedge reset_n) begin
             // Release freeze only on a quiet CE phase to avoid resuming exactly
             // on a CPU/VDP enable pulse edge, which can cause rare load-time
             // glitches or resets in timing-sensitive games.
-            if (!cpu_ce && !vdp_ce) begin
-                ss_freeze <= 0;
-                state     <= ST_IDLE;
+            align_timeout <= align_timeout + 22'd1;
+            if (unfreeze_cnt < 8'd255) begin
+                unfreeze_cnt <= unfreeze_cnt + 8'd1;
+                ss_freeze <= 1;
+            end else if (is_old_format || (video_state_out[21:4] == video_snap[21:4]) || (align_timeout >= 22'd2200000)) begin
+                if (!cpu_ce && !vdp_ce && !pix_ce && !sp_ce) begin
+                    ss_freeze    <= 0;
+                    unfreeze_cnt <= 8'd0;
+                    state        <= ST_UNFREEZE_SETTLE;
+                end else begin
+                    ss_freeze <= 1;
+                end
             end else begin
                 ss_freeze <= 1;
+            end
+        end
+
+        ST_UNFREEZE_SETTLE: begin
+            ss_freeze <= 0;
+            if (unfreeze_cnt == 8'd4) begin
+                op_cooldown <= OP_COOLDOWN_MAX;
+                state       <= ST_IDLE;
+            end else begin
+                unfreeze_cnt <= unfreeze_cnt + 8'd1;
             end
         end
         // ---------------------------------------------------------------

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -138,8 +138,8 @@ entity system is
 		BIOSWEN: IN  STD_LOGIC;
 
 		-- Save-state interface
-		z80_reg_out  : out STD_LOGIC_VECTOR(211 downto 0);
-		z80_dir      : in  STD_LOGIC_VECTOR(211 downto 0) := (others => '0');
+		z80_reg_out  : out STD_LOGIC_VECTOR(229 downto 0);
+		z80_dir      : in  STD_LOGIC_VECTOR(229 downto 0) := (others => '0');
 		z80_set      : in  STD_LOGIC := '0';
 		vdp_regs_out : out STD_LOGIC_VECTOR(127 downto 0);
 		vdp_regs_in  : in  STD_LOGIC_VECTOR(127 downto 0) := (others => '0');
@@ -165,7 +165,33 @@ entity system is
 		-- MREQ_n: low = normal opcode fetch, high = interrupt acknowledge
 		z80_mreq_n   : out STD_LOGIC;
 		-- ISet: "00" = no prefix active (clean instruction boundary)
-		z80_iset     : out STD_LOGIC_VECTOR(1 downto 0)
+		z80_iset     : out STD_LOGIC_VECTOR(1 downto 0);
+		-- Save-state interface for VDP2 (System E second VDP)
+		vdp2_regs_out : out STD_LOGIC_VECTOR(127 downto 0);
+		vdp2_regs_in  : in  STD_LOGIC_VECTOR(127 downto 0) := (others => '0');
+		vdp2_regs_set : in  STD_LOGIC := '0';
+		vdp2_cram_out : out STD_LOGIC_VECTOR(383 downto 0);
+		ss_cram2_wr   : in  STD_LOGIC := '0';
+		ss_cram2_A    : in  STD_LOGIC_VECTOR(4 downto 0)  := (others => '0');
+		ss_cram2_D    : in  STD_LOGIC_VECTOR(11 downto 0) := (others => '0');
+		ss_vram2_en   : in  STD_LOGIC := '0';
+		ss_vram2_A    : in  STD_LOGIC_VECTOR(14 downto 0) := (others => '0');
+		ss_vram2_D    : out STD_LOGIC_VECTOR(7 downto 0);
+		ss_vram2_WE   : in  STD_LOGIC := '0';
+		ss_vram2_WA   : in  STD_LOGIC_VECTOR(14 downto 0) := (others => '0');
+		ss_vram2_WD   : in  STD_LOGIC_VECTOR(7 downto 0)  := (others => '0');
+		-- Save-state interface for PSG2 (System E second PSG)
+		psg2_out      : out STD_LOGIC_VECTOR(55 downto 0);
+		psg2_in       : in  STD_LOGIC_VECTOR(55 downto 0) := (others => '0');
+		psg2_set      : in  STD_LOGIC := '0';
+		-- Save-state interface for IO registers
+		io_state_out  : out STD_LOGIC_VECTOR(31 downto 0);
+		io_state_in   : in  STD_LOGIC_VECTOR(31 downto 0) := (others => '0');
+		io_state_set  : in  STD_LOGIC := '0';
+		-- System E hardware pause: gates Z80 clock independently of ce_pix
+		-- (ce_pix keeps running so VDP scanout and sync are unaffected)
+		se_pause      : in  STD_LOGIC := '0';
+		ss_freeze     : in  STD_LOGIC := '0'
 	);
 end system;
 
@@ -228,6 +254,13 @@ architecture Behavioral of system is
 	signal vdp_se_bank:		std_logic := '0';
 	signal vdp2_se_bank:		std_logic := '0';
 	signal vdp_cpu_bank:		std_logic := '0';
+
+	-- VDP2 save-state internal wires (System E)
+	signal vdp2_regs_out_i   : std_logic_vector(127 downto 0);
+	signal vdp2_cram_out_i   : std_logic_vector(383 downto 0);
+	signal vdp2_vram_D_i     : std_logic_vector(7 downto 0);
+	-- PSG2 save-state internal wire
+	signal psg2_out_i        : std_logic_vector(55 downto 0);
 	signal rom_bank:			std_logic_vector(3 downto 0) := "0000";
 
 	signal PSG_disable:		std_logic;
@@ -548,7 +581,20 @@ begin
 		ysj_quirk	=> ysj_quirk,
 --		mask_column => mask2_column,
 		black_column => black_column,
-		reset_n  => RESET_n
+		reset_n  => RESET_n,
+		ss_regs_out => vdp2_regs_out_i,
+		ss_regs_in  => vdp2_regs_in,
+		ss_regs_set => vdp2_regs_set,
+		ss_cram_out => vdp2_cram_out_i,
+		ss_cram_wr  => ss_cram2_wr,
+		ss_cram_A   => ss_cram2_A,
+		ss_cram_D   => ss_cram2_D,
+		ss_vram_en  => ss_vram2_en,
+		ss_vram_A   => ss_vram2_A,
+		ss_vram_D   => vdp2_vram_D_i,
+		ss_vram_WE  => ss_vram2_WE,
+		ss_vram_WA  => ss_vram2_WA,
+		ss_vram_WD  => ss_vram2_WD
 	);
 
 	psg_inst: jt89
@@ -581,7 +627,10 @@ begin
 		soundL	=> PSG2_outL,
 		soundR	=> PSG2_outR,
 
-		rst		=> not RESET_n
+		rst		=> not RESET_n,
+		ss_out => psg2_out_i,
+		ss_set => psg2_set,
+		ss_in  => psg2_in
 	);
 	
 	fm: work.opll
@@ -603,7 +652,7 @@ begin
 			if RESET_n='0' then
 				fm_d <= (others => '0');
 				fm_a <= '0';
-			elsif fm_WR_n='0' then
+			elsif ss_freeze = '0' and fm_WR_n='0' then
 				fm_d <= D_in;
 				fm_a <= A(0);
 			end if;
@@ -714,14 +763,28 @@ port map(
 		gg_link_nmi_n => gg_link_nmi_n,
 		systeme	=> systeme,
 		region	=> region,
+		vdp_enables   => vdp_enables,
+		psg_enables   => psg_enables,
+		se_mapper_in  => mapper_in(7 downto 0),
+		se_mapper_set => mapper_set,
+		io_state_out  => io_state_out,
+		io_state_in   => io_state_in,
+		io_state_set  => io_state_set,
+		ss_freeze     => ss_freeze,
 		RESET_n	=> RESET_n
 	);
 	
-	ce_z80 <= ce_pix when (systeme = '1' or turbo='1') else ce_cpu;
+	ce_z80 <= '0' when se_pause='1' else
+	          ce_pix when (systeme = '1' or turbo='1') else ce_cpu;
 	io_cycle <= '1' when IORQ_n='0' and M1_n='1' else '0';
 	z80_m1_n   <= M1_n;
 	z80_mreq_n <= MREQ_n;
 	z80_iset   <= z80_iset_int;
+	-- VDP2 / PSG2 SS output port connections
+	vdp2_regs_out <= vdp2_regs_out_i;
+	vdp2_cram_out <= vdp2_cram_out_i;
+	ss_vram2_D    <= vdp2_vram_D_i;
+	psg2_out      <= psg2_out_i;
 	io_upper_port <= '1' when A(7 downto 6)="11" else '0';
 	io_sms_port <= '1' when A(7 downto 6)="00" and (A(0)='1' or (gg='1' and A(5 downto 3)="000")) else '0';
 	io_gg_port <= '1' when gg='1' and A(7 downto 3)="00000" and A(2 downto 1)/="11" else '0';
@@ -850,10 +913,10 @@ port map(
 	det_WR_n <= WR_n when IORQ_n='0' and M1_n='1' and A(7 downto 0)=x"F2" else '1';
 	IRQ_n <= vdp_IRQ_n when systeme='0' else vdp2_IRQ_n;
 					
-	ram_WR   <= not WR_n when MREQ_n='0' and A(15 downto 14)="11" and sc_cart_ram_32k='0' else '0';
-	vram_WR  <= not WR_n when MREQ_n='0' and A(15 downto 14)="10" and vdp_cpu_bank='1' and systeme='1' else '0';
-	vram2_WR  <= not WR_n when MREQ_n='0' and A(15 downto 14)="10" and vdp_cpu_bank='0' and systeme='1' else '0';
-	nvram_WR <= not WR_n when MREQ_n='0' and (((A(15 downto 14)="10" and nvram_e = '1')
+	ram_WR   <= not WR_n when ss_freeze = '0' and MREQ_n='0' and A(15 downto 14)="11" and sc_cart_ram_32k='0' else '0';
+	vram_WR  <= not WR_n when ss_freeze = '0' and MREQ_n='0' and A(15 downto 14)="10" and vdp_cpu_bank='1' and systeme='1' else '0';
+	vram2_WR  <= not WR_n when ss_freeze = '0' and MREQ_n='0' and A(15 downto 14)="10" and vdp_cpu_bank='0' and systeme='1' else '0';
+	nvram_WR <= not WR_n when ss_freeze = '0' and MREQ_n='0' and (((A(15 downto 14)="10" and nvram_e = '1')
 						or (A(15 downto 14)="11" and nvram_ex = '1') 
 						or (A(15 downto 13)="101" and nvram_cme = '1'))
 						or sc_cart_ram_low='1'
@@ -875,7 +938,7 @@ port map(
 				-- disabled (bootloader_n=1) would leave bootloader_n=0 (reset default)
 				-- so the Z80 would read BIOS ROM instead of cart ROM → instant crash.
 				bootloader_n <= mapper_in(54);
-			elsif ctl_WR_n='0' then
+			elsif ss_freeze = '0' and ctl_WR_n='0' then
 				if ext_bios_sel='1' and ext_bios_loaded='1' then
 					-- For external BIOS: honour port $3E bit 3 (active low BIOS enable)
 					-- bit3=0 -> BIOS ROM enabled -> bootloader_n=0
@@ -918,9 +981,9 @@ port map(
 			if RESET_n='0' then 
 				det_D <= "111";
 				PSG_mux <= x"FF";
-			elsif det_WR_n='0' then
+			elsif ss_freeze = '0' and det_WR_n='0' then
 				det_D <= D_in(2 downto 0);
-			elsif bal_WR_n='0' then
+			elsif ss_freeze = '0' and bal_WR_n='0' then
 				PSG_mux <= D_in;
 			end if;
 		end if;
@@ -979,7 +1042,18 @@ port map(
 			mapper_msx <= '0' ;
 		else
 			if rising_edge(clk_sys) then
-			if bootloader_n='1' and sc3000_en='0' and mapper_wonderkid='0' and not mapper_msx_lock then
+				if mapper_set = '1' then
+					mapper_msx <= mapper_in(56);
+					if mapper_in(56) = '1' then
+						mapper_msx_lock <= true;
+						mapper_msx_lock0 <= true;
+					else
+						mapper_msx_lock <= false;
+						mapper_msx_lock0 <= false;
+						mapper_msx_check0 <= false;
+						mapper_msx_check1 <= false;
+					end if;
+				elsif ss_freeze = '0' and bootloader_n='1' and sc3000_en='0' and mapper_wonderkid='0' and not mapper_msx_lock then
 					if MREQ_n='0' then 
 					-- in this state, A is stable but not D_out
 						if A=x"0000" then
@@ -1029,11 +1103,18 @@ port map(
 		else
 			if rising_edge(clk_sys) then
 				if mapper_set = '1' then
-					bank0              <= mapper_in(7 downto 0);
+					-- For System E, mapper_in(7:0) is IO port 0xF7 state (VDP bank
+					-- selects + rom_bank), NOT bank0.  The IO module restores the
+					-- SE banking via se_mapper_set, so skip bank0/pak4_reg0 here.
+					if systeme = '0' then
+						bank0          <= mapper_in(7 downto 0);
+					end if;
 					bank1              <= mapper_in(15 downto 8);
 					bank2              <= mapper_in(23 downto 16);
 					bank3              <= mapper_in(31 downto 24);
-					pak4_reg0          <= mapper_in(7 downto 0);
+					if systeme = '0' then
+						pak4_reg0      <= mapper_in(7 downto 0);
+					end if;
 					pak4_reg2          <= mapper_in(39 downto 32);
 					nem_bank0          <= mapper_in(47 downto 40);
 					nvram_e            <= mapper_in(50);
@@ -1044,6 +1125,11 @@ port map(
 					mapper_codies      <= mapper_in(58);
 					lock_mapper_B      <= mapper_in(59);
 					mapper_codies_lock <= mapper_in(60);
+					-- Prevent edge detector registers from triggering false transitions
+					-- in the next clock cycle after state restoration.
+					bootloader_n_prev     <= bootloader_n;
+					reset_n_prev          <= RESET_n;
+					mapper_wonderkid_prev <= mapper_wonderkid;
 				else
 				if bootloader_n = '0' and mapper_manual_force = '0' then
 					lock_mapper_B <= '0';
@@ -1098,8 +1184,10 @@ port map(
 				mapper_wonderkid_prev <= mapper_wonderkid;
 				reset_n_prev <= RESET_n;
 				bootloader_n_prev <= bootloader_n;
-				if WR_n='1' and MREQ_n='0' then
-					last_read_addr <= A; -- gyurco anti-ldir patch
+				if ce_z80 = '1' then
+					if WR_n='1' and MREQ_n='0' then
+						last_read_addr <= A; -- gyurco anti-ldir patch
+					end if;
 				end if;
 
 				if systeme = '1' or sc3000_en = '1' or mapper_castle = '1' or mapper_linear = '1' or mapper_dahjee_a = '1' or mapper_sega_locked = '1' then
@@ -1109,7 +1197,7 @@ port map(
 					-- $3FFE: reg0=D; bank0=D; bank2=(reg0[5:4]+reg2)
 					-- $7FFF: bank1=D (independent)
 					-- $BFFF: reg2=D; bank2=(reg0[5:4]+D)
-					if WR_n='0' and MREQ_n='0' then
+					if ss_freeze = '0' and WR_n='0' and MREQ_n='0' then
 						if A=x"3FFE" then
 							pak4_reg0 <= D_in;
 							bank0 <= D_in;
@@ -1132,7 +1220,7 @@ port map(
 					-- $0000-$1FFF is nem_bank0 (fixed at reset); $2000-$3FFF is always page 1.
 					-- Suppressed while BIOS is running (bootloader_n='0') so the BIOS can
 					-- bank-switch its own pages via the standard Sega mapper ($FFFC-$FFFF).
-					if WR_n='0' and A(15 downto 2)="00000000000000" then
+					if ss_freeze = '0' and WR_n='0' and MREQ_n='0' and A(15 downto 2)="00000000000000" then
 						case A(1 downto 0) is
 							when "00" => bank2 <= D_in;
 							when "01" => bank3 <= D_in;
@@ -1140,7 +1228,7 @@ port map(
 							when "11" => bank1 <= D_in;
 						end case;
 					end if ;
-				elsif mapper_manual_force = '0' and bootloader_n = '1' and WR_n='0' and MREQ_n='0' and A=x"3FFE" then
+				elsif ss_freeze = '0' and mapper_manual_force = '0' and bootloader_n = '1' and WR_n='0' and MREQ_n='0' and A=x"3FFE" then
 					-- 4-PAK All Action: first write to $3FFE when no mapper active
 					mapper_4pak <= '1';
 					pak4_reg0 <= D_in;
@@ -1153,7 +1241,7 @@ port map(
 				else
 					-- No write-triggered Zemina detection here.
 					-- Zemina mode is selected by header/CRC/OSD; once active, writes are handled in the use_zem branch above.
-					if WR_n='0' and A(15 downto 2)="11111111111111" then
+					if ss_freeze = '0' and WR_n='0' and A(15 downto 2)="11111111111111" then
 						-- A write to $FFFC-$FFFF is a Sega mapper register; disable Codemasters
 						-- detection unless it was already confirmed (mapper_codies_lock='1') or forced.
 						if mapper_codies_force = '0' then
@@ -1169,7 +1257,7 @@ port map(
 							when "11" => bank2 <= D_in ; 
 						end case;
 					end if;
-					if WR_n='0' and nvram_e='0' and mapper_lock='0' then
+					if ss_freeze = '0' and WR_n='0' and nvram_e='0' and mapper_lock='0' then
 						case A(15 downto 0) is
 				-- Codemasters
 				-- do not accept writing in adr $0000 (canary) unless we are sure that Codemasters mapper is in use
@@ -1296,11 +1384,14 @@ port map(
 	-- [55]spare [54]bootloader_n [53]nvram_cme [52]nvram_p [51]nvram_ex [50]nvram_e
 	-- [49]detect_sega_locked [48]detect_dahjee_a [47:40]nem_bank0 [39:32]pak4_reg2
 	-- [31:24]bank3 [23:16]bank2 [15:8]bank1 [7:0]bank0
-	mapper_out <= detect_linear & detect_wonderkid & detect_castle & mapper_codies_lock &
-	              lock_mapper_B & mapper_codies & mapper_4pak & '0' &
+	-- Note: when systeme='1', bits [7:0] mirror IO port 0xF7:
+	--   [7]=vdp_se_bank [6]=vdp2_se_bank [5]=vdp_cpu_bank [3:0]=rom_bank
+	mapper_out(63 downto 8) <= detect_linear & detect_wonderkid & detect_castle & mapper_codies_lock &
+	              lock_mapper_B & mapper_codies & mapper_4pak & mapper_msx &
 	              '0' & bootloader_n & nvram_cme & nvram_p & nvram_ex & nvram_e &
 	              detect_sega_locked & detect_dahjee_a &
-	              nem_bank0 & pak4_reg2 & bank3 & bank2 & bank1 & bank0;
+	              nem_bank0 & pak4_reg2 & bank3 & bank2 & bank1;
+	mapper_out(7 downto 0) <= vdp_se_bank & vdp2_se_bank & vdp_cpu_bank & '0' & rom_bank when systeme='1' else bank0;
 
 	-- Active for any Zemina-family mapper.
 	-- mapper_zemina_force (OSD): user explicitly selected Zemina mapper.
@@ -1404,6 +1495,11 @@ port map(
 				detect_linear      <= mapper_in(63);
 				detect_dahjee_a    <= mapper_in(48);
 				detect_sega_locked <= mapper_in(49);
+				mapper_detect_ticks <= to_unsigned(65535, 16);
+				castle_write_count <= 0;
+				bank_write_seen <= '0';
+				sega_mapper_write_seen <= '0';
+				wonderkid_write_count <= 0;
 			else
 				if bootloader_n = '0' then
 					mapper_detect_ticks <= (others => '0');
@@ -1417,11 +1513,11 @@ port map(
 					wonderkid_write_count <= 0;
 					sega_mapper_write_seen <= '0';
 				-- run a limited detection window while bootloader is active
-				elsif mapper_detect_ticks /= to_unsigned(65535, mapper_detect_ticks'length) then
+				elsif ss_freeze = '0' and mapper_detect_ticks /= to_unsigned(65535, mapper_detect_ticks'length) then
 					mapper_detect_ticks <= mapper_detect_ticks + 1;
 				end if;
 
-				if bootloader_n = '1' and mapper_manual_force = '0' and mapper_detect_ticks < to_unsigned(65535, mapper_detect_ticks'length) then
+				if ss_freeze = '0' and bootloader_n = '1' and mapper_manual_force = '0' and mapper_detect_ticks < to_unsigned(65535, mapper_detect_ticks'length) then
 					if WR_n = '0' and MREQ_n = '0' then
 						-- Wonder Kid [Proto]: confirm after two $8000 writes during the detection window.
 						if A = x"8000" and mapper_4pak = '0' and mapper_codies = '0' and detect_castle = '0' and detect_dahjee_a = '0' and sega_mapper_write_seen = '0' then
@@ -1465,7 +1561,7 @@ port map(
 				-- Dahjee Type A: watch for writes to $2000-$3FFF at any point during boot.
 				-- $2000-$3FFF is ROM space; standard Sega games never write here.
 				-- $3FFE is the 4-PAK reg0 address and is explicitly excluded.
-				if bootloader_n = '1' and mapper_manual_force = '0' and WR_n = '0' and MREQ_n = '0' then
+				if ss_freeze = '0' and bootloader_n = '1' and mapper_manual_force = '0' and WR_n = '0' and MREQ_n = '0' then
 					if A(15 downto 13) = "001" and A /= x"3FFE" then
 						detect_dahjee_a <= '1';
 					end if;

--- a/rtl/vdp.vhd
+++ b/rtl/vdp.vhd
@@ -214,6 +214,9 @@ begin
 				
 		x					=> x,
 		y					=> y,
+		ss_regs_set		    => ss_regs_set,
+		ss_line_reset		=> ss_regs_set,
+		ss_sprite_reset		=> ss_regs_set,
 
 		color				=> color,
 		palettemode			=> palettemode,
@@ -544,9 +547,8 @@ begin
 	begin
 		if rising_edge(clk_sys) then
 			if ss_regs_set = '1' then
-				-- vbl_irq is transient; starting from asserted state can trigger
-				-- immediate post-restore interrupts on rapid consecutive loads.
-				vbl_irq <= '0';
+				-- Restore the interrupt state from save-state instead of clearing it
+				vbl_irq <= ss_regs_in(115);
 			elsif ce_vdp = '1' then
 --				485 instead of 487 to please VDPTEST 
 				if	x=485 and ((y=224 and xmode_M1='1') 
@@ -566,13 +568,9 @@ begin
 		if rising_edge(clk_sys) then
 			if ss_regs_set = '1' then
 				last_x0 <= ss_regs_in(120);
-				-- Restore hbl_counter to irq_line_count, not the mid-frame save-time value.
-				-- We always unfreeze at VBlank end (y=0), where hbl_counter must equal
-				-- irq_line_count (reloaded from it every VBlank by the normal logic).
-				-- Restoring the save-time countdown would cause the first post-restore
-				-- line IRQ to fire at the wrong scanline → garbled scroll effects.
-				hbl_counter <= ss_regs_in(69 downto 62); -- irq_line_count
-				hbl_irq <= '0';
+				-- Restore hbl_counter to the actual saved value from ss_regs_in(111 downto 104).
+				hbl_counter <= ss_regs_in(111 downto 104);
+				hbl_irq <= ss_regs_in(116);
 			elsif ce_vdp = '1' then
 				last_x0 <= std_logic(x(0));
 				if x=486 and not (last_x0=std_logic(x(0))) then
@@ -597,11 +595,21 @@ begin
 	begin
 		if rising_edge(clk_sys) then
 			if ss_regs_set = '1' then
-				irq_delay     <= "111";
+				irq_delay     <= ss_regs_in(114 downto 112);
 				collide_flag  <= ss_regs_in(117);
 				overflow_flag <= ss_regs_in(118);
 				line_overflow <= ss_regs_in(119);
-				IRQ_n         <= '1';
+				xspr_collide_shift <= (others => '0');
+				-- Immediately restore IRQ_n level corresponding to the restored snapshot state
+				if ((ss_regs_in(115) = '1' and ss_regs_in(8) = '1') or (ss_regs_in(116) = '1' and ss_regs_in(3) = '1')) then
+					if ss_regs_in(114 downto 112) = "000" then
+						IRQ_n <= '0';
+					else
+						IRQ_n <= '1';
+					end if;
+				else
+					IRQ_n <= '1';
+				end if;
 			else
 				-- using the other phase of ce_vdp permits to please VDPTEST ovr HCounter
 				-- very tight condition;

--- a/rtl/vdp_background.vhd
+++ b/rtl/vdp_background.vhd
@@ -25,6 +25,7 @@ port (
 	screen_y:			in  std_logic_vector(8 downto 0);
 	text_fg_color:		in  std_logic_vector(3 downto 0);
 	overscan:			in  std_logic_vector(3 downto 0);
+	ss_restore:			in  std_logic := '0';
 
 	vram_A:				out std_logic_vector(13 downto 0);
 	vram_D:				in  std_logic_vector(7 downto 0);
@@ -79,7 +80,15 @@ begin
 	-- -------------------------------------------------------------------------
 	process (clk_sys) begin
 		if rising_edge(clk_sys) then
-			if ce_pix = '1' then
+			if ss_restore = '1' then
+				if smode_M4='0' then
+					x <= "11110000" ; -- 240
+				elsif disable_hscroll='0' or screen_y>=16 then
+					x <= 232-scroll_x;
+				else
+					x <= "11101000"; -- 256-24=232
+				end if;
+			elsif ce_pix = '1' then
 				if (reset='1') then
 					if smode_M4='0' then
 						x <= "11110000" ; -- 240
@@ -107,7 +116,10 @@ begin
 	-- -------------------------------------------------------------------------
 	process (clk_sys) begin
 		if rising_edge(clk_sys) then
-			if ce_pix = '1' then
+			if ss_restore = '1' then
+				text_phase  <= (others=>'0');
+				text_column <= (others=>'0');
+			elsif ce_pix = '1' then
 				if reset='1' or text_mode='0' then
 					text_phase  <= (others=>'0');
 					text_column <= (others=>'0');
@@ -235,7 +247,20 @@ begin
 	-- -------------------------------------------------------------------------
 	process (clk_sys) begin
 		if rising_edge(clk_sys) then
-			if ce_pix = '1' then
+			if ss_restore = '1' then
+				text_tile_index <= (others => '0');
+				text_pattern    <= (others => '0');
+				tile_index      <= (others => '0');
+				flip_x          <= '0';
+				tile_y          <= (others => '0');
+				palette         <= '0';
+				priority_latch  <= '0';
+				data0           <= (others => '0');
+				data1           <= (others => '0');
+				data2           <= (others => '0');
+				data3           <= (others => '0');
+				datac           <= (others => '0');
+			elsif ce_pix = '1' then
 				if text_mode='1' then
 					if conv_integer(screen_x)=1 then
 						text_tile_index <= vram_D;
@@ -318,7 +343,15 @@ begin
 	-- -------------------------------------------------------------------------
 	process (clk_sys) begin
 		if rising_edge(clk_sys) then
-			if ce_pix = '1' then
+			if ss_restore = '1' then
+				text_shift    <= (others => '0');
+				shift0        <= (others => '0');
+				shift1        <= (others => '0');
+				shift2        <= (others => '0');
+				shift3        <= (others => '0');
+				palette_shift <= '0';
+				priority      <= '0';
+			elsif ce_pix = '1' then
 				if text_mode='1' then
 					if conv_integer(screen_x)=7 then
 						text_shift <= text_pattern(7 downto 2);

--- a/rtl/vdp_main.vhd
+++ b/rtl/vdp_main.vhd
@@ -53,7 +53,11 @@ entity vdp_main is
 		spr_tall:			in  std_logic;
 		spr_wide:			in  std_logic;
 		spr_collide:		out std_logic;
-		spr_overflow:		out std_logic);	
+		spr_overflow:		out std_logic;
+		-- Save-state: passed through to sprite scanner reset
+		ss_regs_set:		in  STD_LOGIC := '0';
+		ss_line_reset:		in  std_logic := '0';
+		ss_sprite_reset:	in  std_logic := '0');
 end vdp_main;
 
 architecture Behavioral of vdp_main is
@@ -101,7 +105,7 @@ begin
 		table_address	=> bg_address,
 		pt_address		=> m2mg_address,
 		ct_address		=> m2ct_address,
-		reset				=> line_reset,
+		reset				=> line_reset or ss_line_reset,
 		disable_hscroll=> disable_hscroll,
 		scroll_x 		=> bg_scroll_x,
 		y					=> bg_y,
@@ -120,6 +124,7 @@ begin
 		ysj_quirk			=> ysj_quirk,
 		text_fg_color	=> text_fg_color,
 		overscan			=> overscan,
+		ss_restore			=> ss_regs_set,
 		priority			=> bg_priority);
 		
 	vdp_spr_inst: entity work.vdp_sprites
@@ -146,7 +151,9 @@ begin
 		smode_M4			=> smode_M4,
 		vram_A			=> spr_vram_A,
 		vram_D			=> vram_D,		
-		color				=> spr_color);
+		color				=> spr_color,
+		ss_regs_set		=> ss_regs_set,
+		ss_reset		=> ss_sprite_reset);
 
 	process (x, y, mask_column0, bg_priority, spr_color, bg_color, overscan, display_on, ggres, smode_M1, smode_M3, text_mode)
 		variable spr_active	: boolean;

--- a/rtl/vdp_sprite_shifter.vhd
+++ b/rtl/vdp_sprite_shifter.vhd
@@ -19,7 +19,8 @@ Port(
 	spr_d2: in  std_logic_vector (7 downto 0);
 	spr_d3: in  std_logic_vector (7 downto 0);
 	color : out std_logic_vector (3 downto 0);
-	active: out std_logic
+	active: out std_logic;
+	ss_regs_set: in std_logic := '0'
 );
 end vpd_sprite_shifter;
 
@@ -34,7 +35,13 @@ begin
 
 	process (clk_sys)	begin
 		if rising_edge(clk_sys) then
-			if ce_pix = '1' then
+			if ss_regs_set = '1' then
+				shift0 <= (others => '0');
+				shift1 <= (others => '0');
+				shift2 <= (others => '0');
+				shift3 <= (others => '0');
+				wideclock <= false;
+			elsif ce_pix = '1' then
 				if (spr_x=x and ((load and (m4 or spr_d3(7)='0')) or 
 									 (x224 and spr_d3(7)='1'))) or 
 					(spr_x=x+8 and x248) then

--- a/rtl/vdp_sprites.vhd
+++ b/rtl/vdp_sprites.vhd
@@ -27,7 +27,10 @@ port (
 	y					: in  STD_LOGIC_VECTOR (8 downto 0);
 	collide			: out std_logic;
 	overflow			: out std_logic;
-	color				: out STD_LOGIC_VECTOR (3 downto 0));
+	color				: out STD_LOGIC_VECTOR (3 downto 0);
+	-- Save-state: reset scanner to clean state when '1' (held one cycle)
+	ss_regs_set		: in  STD_LOGIC := '0';
+	ss_reset		: in  STD_LOGIC := '0');
 end vdp_sprites;
 
 architecture Behavioral of vdp_sprites is
@@ -86,7 +89,8 @@ begin
 			spr_d2=> spr_d2(i),
 			spr_d3=> spr_d3(i),
 			color => spr_color(i),
-			active=> spr_active(i)
+			active=> spr_active(i),
+			ss_regs_set => ss_regs_set or ss_reset
 		);
 
 	end generate;
@@ -117,7 +121,22 @@ begin
 		variable delta : std_logic_vector(8 downto 0);
 	begin
 		if rising_edge(clk_sys) then
-			if ce_spload='1' then
+			-- Save-state restore: reset scanner fully so first frame after load
+			-- uses correct sprite data for y=0 (no stale phantom sprites/state).
+			if ss_regs_set = '1' or ss_reset = '1' then
+				count    <= 0;
+				enable   <= (others => false);
+				state    <= WAITING;
+				index    <= (others => '0');
+				overflow <= '0';
+				for i in 0 to MAX_SPPL loop
+					spr_x(i)  <= (others => '0');
+					spr_d0(i) <= (others => '0');
+					spr_d1(i) <= (others => '0');
+					spr_d2(i) <= (others => '0');
+					spr_d3(i) <= (others => '0');
+				end loop;
+			elsif ce_spload='1' then
 			
 				if x=257 then  -- we need step 256 to display the very last sprite pixel
 									-- and one more pixel because the test here is made sync'ed

--- a/rtl/video.vhd
+++ b/rtl/video.vhd
@@ -17,6 +17,10 @@ entity video is
 		smode_M3:		in	 std_logic;
 		smode_M4:		in	 std_logic;
 		
+		video_state_out: out std_logic_vector(21 downto 0);
+		video_state_in:  in  std_logic_vector(21 downto 0) := (others => '0');
+		video_state_set: in  std_logic := '0';
+		
 		x: 				out std_logic_vector(8 downto 0);
 		y:					out std_logic_vector(8 downto 0);
 		hsync:			out std_logic;
@@ -29,6 +33,11 @@ architecture Behavioral of video is
 
 	signal hcount:			std_logic_vector(8 downto 0) := (others => '0');
 	signal vcount:			std_logic_vector(8 downto 0) := (others => '0');
+	
+	signal hsync_reg:		std_logic := '0';
+	signal vsync_reg:		std_logic := '0';
+	signal hblank_reg:		std_logic := '0';
+	signal vblank_reg:		std_logic := '0';
 
 	signal vbl_st,vbl_end: std_logic_vector(8 downto 0);
 	signal hbl_st,hbl_end: std_logic_vector(8 downto 0);
@@ -37,7 +46,12 @@ begin
 	process (clk)
 	begin
 		if rising_edge(clk) then
-			if ce_pix = '1' then
+			if video_state_set = '1' then
+				hcount <= video_state_in(21 downto 13);
+				vcount <= video_state_in(12 downto 4);
+				hsync_reg <= video_state_in(3);
+				vsync_reg <= video_state_in(2);
+			elsif ce_pix = '1' then
 				if hcount=487	then
 					vcount <= vcount + 1;
 					if pal = '1' then
@@ -46,26 +60,26 @@ begin
 							if vcount = 258 then
 								vcount <= conv_std_logic_vector(458,9); 
 							elsif vcount = 461 then
-								vsync <= '1';
+								vsync_reg <= '1';
 							elsif vcount = 464 then
-								vsync <= '0';
+								vsync_reg <= '0';
 							end if;
 						elsif smode_M3='1' and smode_M2='1' then
 							if vcount = 266 then
 								vcount <= conv_std_logic_vector(482,9);
 							elsif vcount = 482 then
-								vsync <= '1';
+								vsync_reg <= '1';
 							elsif vcount = 485 then
-								vsync <= '0';
+								vsync_reg <= '0';
 							end if;
 						else
 						-- VCounter: 0-242, 442-511 = 313 steps
 							if vcount = 242 then
 								vcount <= conv_std_logic_vector(442,9);
 							elsif vcount = 442 then
-								vsync <= '1';
+								vsync_reg <= '1';
 							elsif vcount = 445 then
-								vsync <= '0';
+								vsync_reg <= '0';
 							end if;
 						end if;
 					else
@@ -74,27 +88,27 @@ begin
 							if vcount = 234 then 
 								vcount <= conv_std_logic_vector(485,9);
 							elsif vcount = 487 then
-								vsync <= '1';
+								vsync_reg <= '1';
 							elsif vcount = 490 then
-								vsync <= '0';
+								vsync_reg <= '0';
 							end if;
 					-- NTSC mode 240 lines -- this mode is not suposed to work anyway
 					elsif smode_M3='1' and smode_M2='1' then 
 							if vcount = 261 then -- needs to be > 240 to generate an IRQ
 								vcount <= conv_std_logic_vector(0,9);
 							elsif vcount = 257 then
-								vsync <= '1';
+								vsync_reg <= '1';
 							elsif vcount = 260 then
-								vsync <= '0';
+								vsync_reg <= '0';
 							end if;
 						else
 						-- VCounter: 0-218, 469-511 = 262 steps
 							if vcount = 218 then
 								vcount <= conv_std_logic_vector(469,9);
 							elsif vcount = 471 then
-								vsync <= '1';
+								vsync_reg <= '1';
 							elsif vcount = 474 then
-								vsync <= '0';
+								vsync_reg <= '0';
 							end if;
 						end if;
 					end if;
@@ -106,9 +120,9 @@ begin
 					hcount <= conv_std_logic_vector(466,9);
 				end if;
 				if hcount = 280 then
-					hsync <= '1';
+					hsync_reg <= '1';
 				elsif hcount = 474 then
-					hsync <= '0';
+					hsync_reg <= '0';
 				end if;
 			end if;
 		end if;
@@ -116,6 +130,12 @@ begin
 
 	x	<= hcount;
 	y	<= vcount;
+	hsync <= hsync_reg;
+	vsync <= vsync_reg;
+	hblank <= hblank_reg;
+	vblank <= vblank_reg;
+	
+	video_state_out <= hcount & vcount & hsync_reg & vsync_reg & hblank_reg & vblank_reg;
 
 			vbl_st  <= conv_std_logic_vector(184,9) when (smode_M1='1' and smode_M2='1' and ggres='1')
 			else conv_std_logic_vector(224,9) when (smode_M1 = '1' and smode_M2 = '1')
@@ -143,17 +163,20 @@ begin
 	process (clk)
 	begin
 		if rising_edge(clk) then
-			if ce_pix = '1' then
+			if video_state_set = '1' then
+				hblank_reg <= video_state_in(1);
+				vblank_reg <= video_state_in(0);
+			elsif ce_pix = '1' then
 				if (hcount=hbl_end) then
-					hblank <= '0';
+					hblank_reg <= '0';
 				elsif (hcount=hbl_st) then
-					hblank <= '1';
+					hblank_reg <= '1';
 				end if;
 				
 				if (vcount=vbl_end) then
-					vblank <= '0';
+					vblank_reg <= '0';
 				elsif (vcount=vbl_st) then
-					vblank <= '1';
+					vblank_reg <= '1';
 				end if;
 			end if;
 		end if;


### PR DESCRIPTION
This commit:
- Implements SaveStates for System-E games.
- Implements Pause for System-E games.
- Hardens SaveStates for Master System games (fixes occasional freezes/glitches/resets when loading a state)
- Fixes audio and video sync issues when saving/loading states

Note: The save format changed. The new save files are 96KB. Old save files (64 KB) can still be loaded (retro compatibility).

Details:
- Implement System E pause/unpause gating tied to VBlank and add se_paused logic; freeze handling now separates savestate freeze and System E pause. HDMI freeze behavior adjusted.
- Extend savestates to track ROM rolling signature (ss_game_id) to prevent cross-ROM restores and increase slot size/format for System E (VDP2/CRAM2/VRAM2/PSG2 support). Expand DDRAM layout and NVRAM/VRAM/WRAM addressing accordingly.
- Add IO state and System E mapper save/restore hooks in io.vhd (io_state and se_mapper signals) and preserve VDP/PSG enables across restores.
- Introduce additional save-state wires for VDP2/PSG2/VRAM2 and integrate them into system and savestates instances; wire up video state save/restore.
- Increase Z80/T80 register vector width to include WZ/Halt/Alternate state; propagate changes through T80 and T80s modules and savestates (229-bit register snapshot).
- Update clock gating: provide raw clock refs (clkref_cpu) and gate subsystem clocks when ss_freeze or se_pause_gate active to ensure clean CPU/VDP behavior during save/restore and pause.
- Change joystick handling: add SaveState 'hotkey' masking and remap J1/J2 button indices to new layout; update many .mra release files to expose SaveState button in game configs.
- Add cooldown timer to savestate UI to debounce and rate-limit slot changes/saves/loads (approx 500ms), simplify SS combos to not require Pause, and adjust OSD hint text.
- Video: when System E pause active, mute high bits of RGB to indicate pause; feed video_state wires into video module.
- NVRAM/WRAM address widths adjusted and nvram dpram addressing simplified for savestate DMA.
- Misc: update other small wiring/fixes across RTL modules to support the above changes.

These changes improve savestate reliability, prevent accidental cross-ROM restores, and provide a smoother pause/save/load UX.