### PR TITLE
Fix 4-PAK/Dahjee Type A mapper misdetection for standard Sega-mapper games

### DIFF
--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -1262,8 +1262,8 @@ port map(
 							when "11" => bank1 <= D_in;
 						end case;
 					end if ;
-				elsif ss_freeze = '0' and mapper_manual_force = '0' and bootloader_n = '1' and WR_n='0' and MREQ_n='0' and A=x"3FFE" then
-					-- 4-PAK All Action: first write to $3FFE when no mapper active
+				elsif ss_freeze = '0' and mapper_manual_force = '0' and bootloader_n = '1' and WR_n='0' and MREQ_n='0' and A=x"3FFE" and sega_mapper_write_seen = '0' then
+					-- 4-PAK All Action: first write to $3FFE when no mapper active (gated by sega_mapper_write_seen='0').
 					mapper_4pak <= '1';
 					pak4_reg0 <= D_in;
 					pak4_reg2 <= "00000000";
@@ -1595,7 +1595,8 @@ port map(
 				-- Dahjee Type A: watch for writes to $2000-$3FFF at any point during boot.
 				-- $2000-$3FFF is ROM space; standard Sega games never write here.
 				-- $3FFE is the 4-PAK reg0 address and is explicitly excluded.
-				if ss_freeze = '0' and bootloader_n = '1' and mapper_manual_force = '0' and WR_n = '0' and MREQ_n = '0' then
+				-- Gated by sega_mapper_write_seen='0' to prevent misdetection after boot.
+				if ss_freeze = '0' and bootloader_n = '1' and mapper_manual_force = '0' and WR_n = '0' and MREQ_n = '0' and sega_mapper_write_seen = '0' then
 					if A(15 downto 13) = "001" and A /= x"3FFE" then
 						detect_dahjee_a <= '1';
 					end if;


### PR DESCRIPTION
The 4-PAK All Action heuristic (added in a2c0a09) reclassifies the cart as a 4-PAK on the first write to $3FFE, with no check against whether the game has already proven itself a standard Sega-mapper title via a $FFFC-$FFFF write. Any standard-mapper game that writes to $3FFE for any reason, at any point during gameplay, gets silently and permanently misdetected, corrupting bank addressing.

Bugs Bunny in Double Trouble (GG) hits exactly this: it initializes the standard Sega mapper registers at reset, then later writes to $3FFE, flipping it into 4-PAK mode and producing a black screen. Forcing "Sega" via the OSD mapper override worked around it by short-circuiting the detector entirely, confirming the misdetection.

Gate the 4-PAK heuristic behind sega_mapper_write_seen='0', matching the precedent already used for Wonder Kid detection. A real 4-PAK cart has no $FFFC-$FFFF registers, so this can only suppress false positives and cannot affect genuine 4-PAK carts.

The Dahjee Type A heuristic (watches $2000-$3FFF, added in d17f5b9) has the identical gap - unbounded for the whole session, with no check against an already-confirmed standard mapper - so it gets the same guard as a preventive fix, even though it wasn't the cause of this particular bug.