### PR TITLE
Add F1-F4 savestate keyboard slot hotkeys

### DIFF
--- a/rtl/savestate_ui.sv
+++ b/rtl/savestate_ui.sv
@@ -19,7 +19,9 @@
 //   SS + Down              → save state
 //   SS + Up                → load state
 //
-// PS/2 keyboard:  F1 = load state,  Alt+F1 = save state
+// PS/2 keyboard:
+//   F1-F4     = load slots 1-4
+//   Alt+F1-F4 = save slots 1-4
 
 module savestate_ui (
     input             clk,
@@ -53,6 +55,7 @@ reg statusUpdate_pending;
 // PS/2 state
 reg ps2_stb;
 reg alt_held;
+reg [1:0] kbd_slot;
 reg kbd_save, kbd_load;
 
 // Joystick edge trackers
@@ -70,7 +73,7 @@ reg old_osd_save, old_osd_load;
 reg [27:0] cooldown_cnt = 0;
 
 // -----------------------------------------------------------------------
-// PS/2 keyboard: F1 = load,  Alt+F1 = save
+// PS/2 keyboard: F1-F4 = load, Alt+F1-F4 = save
 // -----------------------------------------------------------------------
 always @(posedge clk) begin
     ps2_stb  <= ps2_key[10];
@@ -78,11 +81,32 @@ always @(posedge clk) begin
     kbd_load <= 0;
 
     if (ps2_stb ^ ps2_key[10]) begin
+        // Accept both left Alt and right Alt (AltGr).
         if (ps2_key[7:0] == 8'h11)
             alt_held <= ps2_key[9];
-        if (ps2_key[7:0] == 8'h05 && ps2_key[9]) begin
-            if (alt_held) kbd_save <= 1;
-            else          kbd_load <= 1;
+
+        // PS/2 Set-2 scan codes:
+        // F1=05, F2=06, F3=04, F4=0C
+        if (ps2_key[9]) begin
+            case (ps2_key[7:0])
+                8'h05: begin
+                    kbd_slot <= 2'd0; // F1: slot 1
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                8'h06: begin
+                    kbd_slot <= 2'd1; // F2: slot 2
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                8'h04: begin
+                    kbd_slot <= 2'd2; // F3: slot 3
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                8'h0C: begin
+                    kbd_slot <= 2'd3; // F4: slot 4
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                default: ;
+            endcase
         end
     end
 end
@@ -160,16 +184,22 @@ always @(posedge clk) begin
     end
 
     // PS/2 keyboard shortcuts
-    if (kbd_save & allow_ss && (cooldown_cnt == 0)) begin
-        ss_save      <= 1;
+    if ((kbd_save | kbd_load) & allow_ss && (cooldown_cnt == 0)) begin
+        // Keyboard shortcuts address a slot directly, rather than using
+        // the slot which happened to be selected before the keypress.
+        slot                 <= kbd_slot;
+        selected_slot        <= kbd_slot;
+        statusUpdate_pending <= 1;
         ss_info_req  <= 1;
-        ss_info      <= 8'd6 + {slot, 1'b0};
-        cooldown_cnt <= 28'd26846500;          // 500ms cooldown
-    end
-    if (kbd_load & allow_ss && (cooldown_cnt == 0)) begin
-        ss_load      <= 1;
-        ss_info_req  <= 1;
-        ss_info      <= 8'd7 + {slot, 1'b0};
+
+        if (kbd_save) begin
+            ss_save <= 1;
+            ss_info <= 8'd6 + {kbd_slot, 1'b0};
+        end else begin
+            ss_load <= 1;
+            ss_info <= 8'd7 + {kbd_slot, 1'b0};
+        end
+
         cooldown_cnt <= 28'd26846500;          // 500ms cooldown
     end
 


### PR DESCRIPTION
Expand PS/2 savestate shortcuts from only F1/Alt+F1 to F1-F4 for loading slots 1-4 and Alt+F1-F4 for saving slots 1-4. The handler now captures the target slot from the pressed function key and applies save/load directly to that slot (updating selected slot/status info), instead of relying on the previously selected slot.