### PR TITLE
Enhance savestate hotkeys and fix various SMS core issues

### DIFF
--- a/rtl/savestate_ui.sv
+++ b/rtl/savestate_ui.sv
@@ -19,7 +19,9 @@
 //   SS + Down              → save state
 //   SS + Up                → load state
 //
-// PS/2 keyboard:  F1 = load state,  Alt+F1 = save state
+// PS/2 keyboard:
+//   F1-F4     = load slots 1-4
+//   Alt+F1-F4 = save slots 1-4
 
 module savestate_ui (
     input             clk,
@@ -53,6 +55,7 @@ reg statusUpdate_pending;
 // PS/2 state
 reg ps2_stb;
 reg alt_held;
+reg [1:0] kbd_slot;
 reg kbd_save, kbd_load;
 
 // Joystick edge trackers
@@ -70,7 +73,7 @@ reg old_osd_save, old_osd_load;
 reg [27:0] cooldown_cnt = 0;
 
 // -----------------------------------------------------------------------
-// PS/2 keyboard: F1 = load,  Alt+F1 = save
+// PS/2 keyboard: F1-F4 = load, Alt+F1-F4 = save
 // -----------------------------------------------------------------------
 always @(posedge clk) begin
     ps2_stb  <= ps2_key[10];
@@ -78,11 +81,32 @@ always @(posedge clk) begin
     kbd_load <= 0;
 
     if (ps2_stb ^ ps2_key[10]) begin
+        // Accept both left Alt and right Alt (AltGr).
         if (ps2_key[7:0] == 8'h11)
             alt_held <= ps2_key[9];
-        if (ps2_key[7:0] == 8'h05 && ps2_key[9]) begin
-            if (alt_held) kbd_save <= 1;
-            else          kbd_load <= 1;
+
+        // PS/2 Set-2 scan codes:
+        // F1=05, F2=06, F3=04, F4=0C
+        if (ps2_key[9]) begin
+            case (ps2_key[7:0])
+                8'h05: begin
+                    kbd_slot <= 2'd0; // F1: slot 1
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                8'h06: begin
+                    kbd_slot <= 2'd1; // F2: slot 2
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                8'h04: begin
+                    kbd_slot <= 2'd2; // F3: slot 3
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                8'h0C: begin
+                    kbd_slot <= 2'd3; // F4: slot 4
+                    if (alt_held) kbd_save <= 1; else kbd_load <= 1;
+                end
+                default: ;
+            endcase
         end
     end
 end
@@ -160,16 +184,22 @@ always @(posedge clk) begin
     end
 
     // PS/2 keyboard shortcuts
-    if (kbd_save & allow_ss && (cooldown_cnt == 0)) begin
-        ss_save      <= 1;
+    if ((kbd_save | kbd_load) & allow_ss && (cooldown_cnt == 0)) begin
+        // Keyboard shortcuts address a slot directly, rather than using
+        // the slot which happened to be selected before the keypress.
+        slot                 <= kbd_slot;
+        selected_slot        <= kbd_slot;
+        statusUpdate_pending <= 1;
         ss_info_req  <= 1;
-        ss_info      <= 8'd6 + {slot, 1'b0};
-        cooldown_cnt <= 28'd26846500;          // 500ms cooldown
-    end
-    if (kbd_load & allow_ss && (cooldown_cnt == 0)) begin
-        ss_load      <= 1;
-        ss_info_req  <= 1;
-        ss_info      <= 8'd7 + {slot, 1'b0};
+
+        if (kbd_save) begin
+            ss_save <= 1;
+            ss_info <= 8'd6 + {kbd_slot, 1'b0};
+        end else begin
+            ss_load <= 1;
+            ss_info <= 8'd7 + {kbd_slot, 1'b0};
+        end
+
         cooldown_cnt <= 28'd26846500;          // 500ms cooldown
     end
 

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -1783,7 +1783,7 @@ port map(
 				-- Detects LD (nn),A (opcode 0x32) sequences targeting $0002/$0003/$0004
 				-- vs $FFFF. No opcode-boundary tracking needed: same approach as MAME.
 				-- ---------------------------------------------------------------
-				if unsigned(ROMAD(14 downto 0)) < 32768 then  -- first 32KB only
+				if unsigned(ROMAD) < 32768 then  -- first 32KB only
 					case zem_scan_state is
 						when 0 =>
 							-- Waiting for 0x32 (LD (nn),A opcode)
@@ -1821,8 +1821,8 @@ port map(
 							zem_scan_state <= 0;
 					end case;
 
-					if unsigned(ROMAD(14 downto 0)) = 32767 then
-						if zem_count_0002 > zem_count_ffff + 2 then
+					if unsigned(ROMAD) = 32767 then
+						if zem_count_0002 > zem_count_ffff + 1 then
 							detect_zemina_static <= '1';
 						end if;
 					end if;

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -442,6 +442,19 @@ architecture Behavioral of system is
 		return crc;
 	end function;
 
+	function reverse8(x : std_logic_vector(7 downto 0)) return std_logic_vector is
+	begin
+		return x(0) & x(1) & x(2) & x(3) & x(4) & x(5) & x(6) & x(7);
+	end function;
+
+	-- Janggun mapper (Janggun-ui Adeul): CRC32-based auto-detection
+	signal mapper_janggun         : std_logic := '0';
+	signal jang_bank1, jang_bank2 : std_logic_vector(5 downto 0) := "000010"; -- $4000 (page 2), $6000 (page 3)
+	signal jang_bank3, jang_bank4 : std_logic_vector(5 downto 0) := "000100"; -- $8000 (page 4), $A000 (page 5)
+	signal jang_rev1, jang_rev2   : std_logic := '0';
+	signal jang_rev3, jang_rev4   : std_logic := '0';
+	signal janggun_reverse_active : std_logic := '0';
+
 	component CODES is
 		generic(
 			ADDR_WIDTH  : in integer := 16;
@@ -1066,6 +1079,13 @@ port map(
 	-- will fall back into the SPRAM BIOS - giving the correct no-cart loop.
 	active_bios_D_out <= ext_bios_D_out when (ext_bios_sel='1' and ext_bios_loaded='1') else boot_rom_D_out;
 
+	janggun_reverse_active <=
+		jang_rev1 when mapper_janggun = '1' and bootloader_n = '1' and A(15 downto 13) = "010" else
+		jang_rev2 when mapper_janggun = '1' and bootloader_n = '1' and A(15 downto 13) = "011" else
+		jang_rev3 when mapper_janggun = '1' and bootloader_n = '1' and A(15 downto 13) = "100" else
+		jang_rev4 when mapper_janggun = '1' and bootloader_n = '1' and A(15 downto 13) = "101" else
+		'0';
+
 	irom_D_out <=	ext_gg_bios_D_out when (bootloader_n='0' and gg_bios_en='1' and ext_gg_bios_loaded='1' and A(15 downto 14)="00")
 	               else active_bios_D_out when (bootloader_n='0' and gg_bios_en='0' and A(15 downto 14)="00")
 	               else ext_bios_D_out when (bootloader_n='0' and gg_bios_en='0' and ext_bios_sel='1' and ext_bios_loaded='1' and A(15 downto 14)/="11")
@@ -1075,7 +1095,9 @@ port map(
 	               -- incorrectly detect a cartridge when none is present.
 	               else x"FF" when (bootloader_n='1' and dbr='0')
 	               else segadect2_D_out when (encrypt(1 downto 0)="10" and A(15)='0')
-						else mc8123_D_out when (encrypt(0)='1' and A(15)='0') or (encrypt(1 downto 0)="11" and A(14)='0') else rom_do;
+						else mc8123_D_out when (encrypt(0)='1' and A(15)='0') or (encrypt(1 downto 0)="11" and A(14)='0')
+						else reverse8(rom_do) when (mapper_janggun = '1' and bootloader_n = '1' and janggun_reverse_active = '1')
+						else rom_do;
 	
 	process (clk_sys)
 	begin
@@ -1189,6 +1211,14 @@ port map(
 			bank1 <= "00000001";
 			bank2 <= "00000010";
 			bank3 <= "00000011";
+			jang_bank1 <= "000010";
+			jang_bank2 <= "000011";
+			jang_bank3 <= "000100";
+			jang_bank4 <= "000101";
+			jang_rev1 <= '0';
+			jang_rev2 <= '0';
+			jang_rev3 <= '0';
+			jang_rev4 <= '0';
 			nvram_e  <= '0';
 			nvram_ex <= '0';
 			nvram_p  <= '0';
@@ -1209,28 +1239,39 @@ port map(
 			if rising_edge(clk_sys) then
 				eeprom_soft_reset <= '0';
 				if mapper_set = '1' then
-					-- For System E, mapper_in(7:0) is IO port 0xF7 state (VDP bank
-					-- selects + rom_bank), NOT bank0.  The IO module restores the
-					-- SE banking via se_mapper_set, so skip bank0/pak4_reg0 here.
-					if systeme = '0' then
-						bank0          <= mapper_in(7 downto 0);
+					if mapper_janggun = '1' then
+						jang_bank1 <= mapper_in(5 downto 0);
+						jang_rev1  <= mapper_in(7);
+						jang_bank2 <= mapper_in(13 downto 8);
+						jang_rev2  <= mapper_in(15);
+						jang_bank3 <= mapper_in(21 downto 16);
+						jang_rev3  <= mapper_in(23);
+						jang_bank4 <= mapper_in(29 downto 24);
+						jang_rev4  <= mapper_in(31);
+					else
+						-- For System E, mapper_in(7:0) is IO port 0xF7 state (VDP bank
+						-- selects + rom_bank), NOT bank0.  The IO module restores the
+						-- SE banking via se_mapper_set, so skip bank0/pak4_reg0 here.
+						if systeme = '0' then
+							bank0          <= mapper_in(7 downto 0);
+						end if;
+						bank1              <= mapper_in(15 downto 8);
+						bank2              <= mapper_in(23 downto 16);
+						bank3              <= mapper_in(31 downto 24);
+						if systeme = '0' then
+							pak4_reg0      <= mapper_in(7 downto 0);
+						end if;
+						pak4_reg2          <= mapper_in(39 downto 32);
+						nem_bank0          <= mapper_in(47 downto 40);
+						nvram_e            <= mapper_in(50);
+						nvram_ex           <= mapper_in(51);
+						nvram_p            <= mapper_in(52);
+						nvram_cme          <= mapper_in(53);
+						mapper_4pak        <= mapper_in(57);
+						mapper_codies      <= mapper_in(58);
+						lock_mapper_B      <= mapper_in(59);
+						mapper_codies_lock <= mapper_in(60);
 					end if;
-					bank1              <= mapper_in(15 downto 8);
-					bank2              <= mapper_in(23 downto 16);
-					bank3              <= mapper_in(31 downto 24);
-					if systeme = '0' then
-						pak4_reg0      <= mapper_in(7 downto 0);
-					end if;
-					pak4_reg2          <= mapper_in(39 downto 32);
-					nem_bank0          <= mapper_in(47 downto 40);
-					nvram_e            <= mapper_in(50);
-					nvram_ex           <= mapper_in(51);
-					nvram_p            <= mapper_in(52);
-					nvram_cme          <= mapper_in(53);
-					mapper_4pak        <= mapper_in(57);
-					mapper_codies      <= mapper_in(58);
-					lock_mapper_B      <= mapper_in(59);
-					mapper_codies_lock <= mapper_in(60);
 					-- Prevent edge detector registers from triggering false transitions
 					-- in the next clock cycle after state restoration.
 					bootloader_n_prev     <= bootloader_n;
@@ -1250,6 +1291,14 @@ port map(
 					bank1 <= "00000001";
 					bank2 <= "00000010";
 					bank3 <= "00000011";
+					jang_bank1 <= "000010";
+					jang_bank2 <= "000011";
+					jang_bank3 <= "000100";
+					jang_bank4 <= "000101";
+					jang_rev1 <= '0';
+					jang_rev2 <= '0';
+					jang_rev3 <= '0';
+					jang_rev4 <= '0';
 					nvram_e  <= '0';
 					nvram_ex <= '0';
 					nvram_p  <= '0';
@@ -1269,6 +1318,16 @@ port map(
 				-- rom_size_pages is stable here because
 				-- cart_download holds RESET_n low throughout the entire ROM transfer.
 				if RESET_n = '1' and reset_n_prev = '0' then
+					if mapper_janggun = '1' then
+						jang_bank1 <= "000010";
+						jang_bank2 <= "000011";
+						jang_bank3 <= "000100";
+						jang_bank4 <= "000101";
+						jang_rev1 <= '0';
+						jang_rev2 <= '0';
+						jang_rev3 <= '0';
+						jang_rev4 <= '0';
+					end if;
 					if mapper_zemina_force = '1' then
 						nem_bank0 <= (others => '0');
 					elsif mapper_nemesis_auto = '1' and unsigned(rom_size_pages) /= 0 then
@@ -1308,7 +1367,42 @@ port map(
 					end if;
 				end if;
 
-				if mapper_eeprom = '1' then
+				if mapper_janggun = '1' and bootloader_n = '1' then
+					if ss_freeze = '0' and WR_n = '0' and MREQ_n = '0' then
+						case A is
+							when x"4000" =>
+								jang_bank1 <= D_in(5 downto 0);
+								jang_rev1  <= D_in(7);
+
+							when x"6000" =>
+								jang_bank2 <= D_in(5 downto 0);
+								jang_rev2  <= D_in(7);
+
+							when x"8000" =>
+								jang_bank3 <= D_in(5 downto 0);
+								jang_rev3  <= D_in(7);
+
+							when x"A000" =>
+								jang_bank4 <= D_in(5 downto 0);
+								jang_rev4  <= D_in(7);
+
+							when x"FFFE" =>
+								jang_bank1 <= D_in(4 downto 0) & '0';
+								jang_bank2 <= D_in(4 downto 0) & '1';
+								jang_rev1  <= D_in(6) or D_in(7);
+								jang_rev2  <= D_in(6) or D_in(7);
+
+							when x"FFFF" =>
+								jang_bank3 <= D_in(4 downto 0) & '0';
+								jang_bank4 <= D_in(4 downto 0) & '1';
+								jang_rev3  <= D_in(6) or D_in(7);
+								jang_rev4  <= D_in(6) or D_in(7);
+
+							when others =>
+								null;
+						end case;
+					end if;
+				elsif mapper_eeprom = '1' then
 					-- EEPROM carts (93C46) always use the plain Sega $FFFC-$FFFF register map.
 					-- Must take priority over every other mapper heuristic below (4-PAK $3FFE
 					-- write-trigger, Zemina opcode scan, Dahjee/linear/castle/etc.) so a false
@@ -1429,8 +1523,12 @@ port map(
 	mapper_manual_force <= mapper_lock or mapper_codies_force or mapper_dahjee_a_force or
 	                       mapper_linear_force or mapper_zemina_force;
 
+	-- Janggun mapper (Janggun-ui Adeul): CRC32-based auto-detection.
+	-- CRC32 0x192949D5
+	mapper_janggun <= '1' when mapper_manual_force = '0' and (rom_crc32 xor x"FFFFFFFF") = x"192949D5" else '0';
+
 	-- Castle mapper heuristic + OSD force.
-	mapper_castle <= '1' when mapper_manual_force = '0' and detect_castle = '1' else
+	mapper_castle <= '1' when mapper_manual_force = '0' and mapper_janggun = '0' and detect_castle = '1' else
 	                 '0';
 
 	-- Wonder Kid [Proto] [SMS-GG]: MAPPER_MSX_Generic16_8000
@@ -1445,13 +1543,11 @@ port map(
 	-- CRC16-CCITT of last 8KB block: 0x8613
 
 	-- Nemesis I requires a special startup mapping: $0000-$1FFF from the last page.
-	mapper_nemesis_auto <= '1' when mapper_manual_force = '0' and
+	mapper_nemesis_auto <= '1' when mapper_manual_force = '0' and mapper_janggun = '0' and
 	                                rom_crc16_run = x"EE05" else
 	                       '0';
 
-
-
-	mapper_wonderkid <= '1' when mapper_manual_force = '0' and
+	mapper_wonderkid <= '1' when mapper_manual_force = '0' and mapper_janggun = '0' and
 	                             (detect_wonderkid = '1' or rom_crc16_run = x"8613") else
 	                    '0';
 
@@ -1463,7 +1559,7 @@ port map(
 	-- rom_a_i branch are handled separately by mapper_sega_locked (see below).
 	-- Linear mapper heuristic + OSD force.
 	mapper_linear <= '1' when mapper_linear_force = '1' else
-	                 '1' when mapper_manual_force = '0' and detect_linear = '1' else
+	                 '1' when mapper_manual_force = '0' and mapper_janggun = '0' and detect_linear = '1' else
 	                 '0';
 
 	-- 48KB dahjee_typeb games: Sega mapper code path (bank registers 0,1,2 never updated)
@@ -1474,7 +1570,7 @@ port map(
 	-- Keeping them on the Sega mapper path (same SDRAM addresses for banks 0,1,2 on 48KB)
 	-- while blocking all write detection fixes both the boot failure and the logo loop.
 	-- Mapper that follows Sega path but locks all bank writes (used for some 48KB linear/dahjee_typeb games)
-	mapper_sega_locked <= '1' when mapper_manual_force = '0' and detect_sega_locked = '1' else '0';
+	mapper_sega_locked <= '1' when mapper_manual_force = '0' and mapper_janggun = '0' and detect_sega_locked = '1' else '0';
 
 	-- Dahjee Type A expansion: linear ROM + 8KB RAM at 0x2000-0x3FFF.
 	-- MSX conversions published by DahJee/Jumbo that require the Type A
@@ -1483,7 +1579,7 @@ port map(
 	-- (MAME devices: sega8_dahjee_typea_device)
 	-- Dahjee Type A heuristic + OSD force.
 	mapper_dahjee_a <= '1' when mapper_dahjee_a_force = '1' else
-	                  '1' when mapper_manual_force = '0' and detect_dahjee_a = '1' else
+	                  '1' when mapper_manual_force = '0' and mapper_janggun = '0' and detect_dahjee_a = '1' else
 	                  '0';
 
 	-- GG EEPROM mapper: CRC32-based auto-detection. 
@@ -1526,13 +1622,24 @@ port map(
 	-- [31:24]bank3 [23:16]bank2 [15:8]bank1 [7:0]bank0
 	-- Note: when systeme='1', bits [7:0] mirror IO port 0xF7:
 	--   [7]=vdp_se_bank [6]=vdp2_se_bank [5]=vdp_cpu_bank [3:0]=rom_bank
-	mapper_out(63 downto 8) <= detect_linear & detect_wonderkid & detect_castle & mapper_codies_lock &
+	mapper_out(63 downto 8) <=
+	              detect_linear & detect_wonderkid & detect_castle & mapper_codies_lock &
+	              lock_mapper_B & mapper_codies & mapper_4pak & mapper_msx &
+	              detect_zemina_static & bootloader_n & nvram_cme & nvram_p & nvram_ex & nvram_e &
+	              detect_sega_locked & detect_dahjee_a &
+	              x"0000" &
+	              jang_rev4 & "0" & jang_bank4 &
+	              jang_rev3 & "0" & jang_bank3 &
+	              jang_rev2 & "0" & jang_bank2 when mapper_janggun = '1' else
+	              detect_linear & detect_wonderkid & detect_castle & mapper_codies_lock &
 	              lock_mapper_B & mapper_codies & mapper_4pak & mapper_msx &
 	              detect_zemina_static & bootloader_n & nvram_cme & nvram_p & nvram_ex & nvram_e &
 	              detect_sega_locked & detect_dahjee_a &
 	              nem_bank0 & pak4_reg2 & bank3 & bank2 & bank1;
 
-	mapper_out(7 downto 0) <= vdp_se_bank & vdp2_se_bank & vdp_cpu_bank & '0' & rom_bank when systeme='1' else bank0;
+	mapper_out(7 downto 0) <= vdp_se_bank & vdp2_se_bank & vdp_cpu_bank & '0' & rom_bank when systeme='1' else
+	                          jang_rev1 & "0" & jang_bank1 when mapper_janggun = '1' else
+	                          bank0;
 
 	-- Active for any Zemina-family mapper.
 	-- detect_zemina_static: MAME-equivalent static opcode scan result.
@@ -1540,6 +1647,7 @@ port map(
 	-- GG guard: no Zemina games exist on Game Gear cartridges.
 	use_zem <= '1' when mapper_zemina_force = '1' else
 	           '0' when mapper_manual_force = '1' else
+	           '0' when mapper_janggun = '1' else
 	           '0' when mapper_wonderkid = '1' else
 	           '0' when mapper_codies = '1' or detect_codies_static = '1' or mapper_codies_force = '1' else
 	           '1' when mapper_nemesis_auto = '1' else
@@ -1549,7 +1657,8 @@ port map(
 	           '0';
 
 	rom_a_i(12 downto 0) <= A(12 downto 0);
-	process (A,bank0,bank1,bank2,bank3,use_zem,nem_bank0,mapper_4pak,mapper_codies,systeme,sc3000_en,sc_multicart_en,sc_multicart_page,rom_bank,bootloader_n,mapper_linear,mapper_dahjee_a)
+	process (A,bank0,bank1,bank2,bank3,use_zem,nem_bank0,mapper_4pak,mapper_codies,systeme,sc3000_en,sc_multicart_en,sc_multicart_page,rom_bank,bootloader_n,mapper_linear,mapper_dahjee_a,
+	         mapper_janggun,jang_bank1,jang_bank2,jang_bank3,jang_bank4)
 	begin
 		if systeme = '1' then
 			case A(15 downto 14) is
@@ -1566,6 +1675,22 @@ port map(
 			-- Keep the full CPU address so ROM pages don't mirror.
 			rom_a_i(21 downto 16) <= (others=>'0');
 			rom_a_i(15 downto 13) <= A(15 downto 13);
+		elsif mapper_janggun = '1' and bootloader_n = '1' then
+			case A(15 downto 13) is
+			when "000" | "001" =>
+				-- $0000-$3FFF fixed: first 16KB / pages 0 and 1
+				rom_a_i(21 downto 13) <= "000000" & A(15 downto 13);
+			when "010" => -- $4000-$5FFF
+				rom_a_i(21 downto 13) <= "000" & jang_bank1;
+			when "011" => -- $6000-$7FFF
+				rom_a_i(21 downto 13) <= "000" & jang_bank2;
+			when "100" => -- $8000-$9FFF
+				rom_a_i(21 downto 13) <= "000" & jang_bank3;
+			when "101" => -- $A000-$BFFF
+				rom_a_i(21 downto 13) <= "000" & jang_bank4;
+			when others =>
+				rom_a_i(21 downto 13) <= "000000" & A(15 downto 13);
+			end case;
 		-- Zemina/Nemesis mapper is suppressed while the BIOS is running (bootloader_n='0').
 		-- This allows large banked BIOSes (e.g. Korean 64KB) to bank-switch their own
 		-- pages via the standard Sega mapper, without nem_bank0 corrupting $0000-$1FFF.

--- a/rtl/vdp.vhd
+++ b/rtl/vdp.vhd
@@ -80,8 +80,8 @@ entity vdp is
 		--  [117]          collide_flag
 		--  [118]          overflow_flag
 		--  [119]          line_overflow
-		--  [120]          last_x0
-		-- Total: 121 bits -> packed into ss_regs[127:0] (16 bytes, 2 DDRAM words)
+		--  [127:120]      bg_scroll_x_latched
+		-- Total: 128 bits -> packed into ss_regs[127:0] (16 bytes, 2 DDRAM words)
 		ss_regs_out    : out STD_LOGIC_VECTOR(127 downto 0);
 		-- Restore: load all VDP control registers at once (held one cycle while ss_regs_set='1')
 		ss_regs_in     : in  STD_LOGIC_VECTOR(127 downto 0) := (others => '0');
@@ -158,6 +158,7 @@ architecture Behavioral of vdp is
 	signal m2mg_address:		std_logic_vector (2 downto 0) := (others=>'0');
 	signal m2ct_address:		std_logic_vector (7 downto 0) := (others=>'1');
 	signal bg_scroll_x:		std_logic_vector(7 downto 0) := (others=>'0');
+	signal bg_scroll_x_latched : std_logic_vector(7 downto 0) := (others => '0');
 	signal bg_scroll_y:		std_logic_vector(7 downto 0) := (others=>'0');
 	signal spr_address:		std_logic_vector (6 downto 0) := (others=>'0');
 	signal spr_shift:			std_logic := '0';
@@ -238,7 +239,7 @@ begin
 		bg_address		=> bg_address,
 		m2mg_address	=> m2mg_address,
 		m2ct_address	=> m2ct_address,
-		bg_scroll_x		=> bg_scroll_x,
+		bg_scroll_x		=> bg_scroll_x_latched,
 		bg_scroll_y		=> bg_scroll_y,
 		disable_hscroll=>disable_hscroll,
 		disable_vscroll => disable_vscroll,
@@ -346,8 +347,7 @@ begin
 	ss_regs_out(117)         	<= collide_flag;
 	ss_regs_out(118)         	<= overflow_flag;
 	ss_regs_out(119)         	<= line_overflow;
-	ss_regs_out(120)         	<= last_x0;
-	ss_regs_out(127 downto 121)	<= (others => '0');
+	ss_regs_out(127 downto 120)	<= bg_scroll_x_latched;
 
 	smode_M1 <= mode_M1 and mode_M2 ;
 	smode_M2 <= mode_M2;
@@ -567,7 +567,7 @@ begin
 	begin
 		if rising_edge(clk_sys) then
 			if ss_regs_set = '1' then
-				last_x0 <= ss_regs_in(120);
+				last_x0 <= std_logic(x(0));
 				-- Restore hbl_counter to the actual saved value from ss_regs_in(111 downto 104).
 				hbl_counter <= ss_regs_in(111 downto 104);
 				hbl_irq <= ss_regs_in(116);
@@ -660,4 +660,23 @@ begin
 		end if;
 	end process;
 	
+	-- YM2602 / Nuked-SMS-FPGA latches R8 at horizontal count 488.
+	-- Captured at x=487 so the updated value is available to the background
+	-- pipeline when line_reset triggers at x=488.
+	process (clk_sys)
+	begin
+		if rising_edge(clk_sys) then
+			if reset_n = '0' then
+				bg_scroll_x_latched <= (others => '0');
+			elsif ss_regs_set = '1' then
+				-- Preserve deterministic behavior after restoring a state.
+				bg_scroll_x_latched <= ss_regs_in(127 downto 120);
+			elsif ce_pix = '1' then
+				if x = conv_std_logic_vector(487, 9) then
+					bg_scroll_x_latched <= bg_scroll_x;
+				end if;
+			end if;
+		end if;
+	end process;
+
 end Behavioral;

--- a/rtl/vdp_background.vhd
+++ b/rtl/vdp_background.vhd
@@ -12,7 +12,7 @@ port (
 	table_address:		in  std_logic_vector(13 downto 10);
 	pt_address:			in  std_logic_vector(13 downto 11);
 	ct_address:			in  std_logic_vector(13 downto 6);
-	scroll_x:			in  std_logic_vector(7 downto 0);
+	scroll_x_latched:	in  std_logic_vector(7 downto 0);
 	disable_hscroll:	in  std_logic;
 	mode_M1_raw:		in  std_logic;
 	mode_M2_raw:		in  std_logic;
@@ -84,7 +84,7 @@ begin
 				if smode_M4='0' then
 					x <= "11110000" ; -- 240
 				elsif disable_hscroll='0' or screen_y>=16 then
-					x <= 232-scroll_x;
+					x <= 232-scroll_x_latched;
 				else
 					x <= "11101000"; -- 256-24=232
 				end if;
@@ -100,7 +100,7 @@ begin
 					elsif disable_hscroll='0' or screen_y>=16 then
 						-- if you mess with this check Sangokushi3 scroll during
 						-- the presentation + scroll of the top line during fight
-						x <= 232-scroll_x;   -- temporary workaround of 1pix roll - needs better fix!
+						x <= 232-scroll_x_latched;   -- temporary workaround of 1pix roll - needs better fix!
 					else
 						x <= "11101000"; -- 256-24=232
 					end if;

--- a/rtl/vdp_main.vhd
+++ b/rtl/vdp_main.vhd
@@ -107,7 +107,7 @@ begin
 		ct_address		=> m2ct_address,
 		reset				=> line_reset or ss_line_reset,
 		disable_hscroll=> disable_hscroll,
-		scroll_x 		=> bg_scroll_x,
+		scroll_x_latched 		=> bg_scroll_x,
 		y					=> bg_y,
 		screen_y			=> y,
 		screen_x			=> x,

--- a/rtl/vdp_sprite_shifter.vhd
+++ b/rtl/vdp_sprite_shifter.vhd
@@ -42,9 +42,14 @@ begin
 				shift3 <= (others => '0');
 				wideclock <= false;
 			elsif ce_pix = '1' then
-				if (spr_x=x and ((load and (m4 or spr_d3(7)='0')) or 
-									 (x224 and spr_d3(7)='1'))) or 
-					(spr_x=x+8 and x248) then
+				-- spr_x=0xFF is the wrapped value produced when the VDP sprite X
+				-- register is 0 (the scanner stores VDP_X-1). Treat it as the
+				-- off-screen predecessor of X=0 instead of allowing it to match
+				-- the right edge through the 8-bit coordinate wrap.
+				if ((spr_x=x and ((load and (m4 or spr_d3(7)='0')) or 
+									 (x224 and spr_d3(7)='1'))) and spr_x/=x"FF")
+					or (spr_x=x"FF" and x=x"00" and load)
+					or (spr_x=x+8 and x248 and spr_x/=x"FF") then
 					shift0 <= spr_d0;
 					shift1 <= spr_d1;
 					shift2 <= spr_d2;
@@ -82,4 +87,3 @@ begin
 		end if;
 	end process;
 end Behavioral;
-


### PR DESCRIPTION
1) Fix two misdetections (regressions from 9084aee7b8a49ff51debe78cd2ba86b541d67ffd)
- "Alex Kidd - The Lost Stars (World)" was incorrectly being detected as Zemina mapper.
- "Super Boy III (Korea) (En) (Unl)" was incorrectly being detected as Sega mapper.
2) Fix "Great Basketball (World)" glitch in the upper right corner of the screen.
3) Adds the mapper for Janggun-ui Adeul (Korea) (Unl), mentioned in https://github.com/MiSTer-devel/SMS_MiSTer/issues/55
4) Fix the issue [#113](https://github.com/MiSTer-devel/SMS_MiSTer/issues/113). SMS core now passes the X-Scroll Latchtime in VDP Test and it doesn't break Samgukji III - Cheonha Jaengpae (Korea) (Unl).

This pull request introduces two main sets of changes: (1) an enhancement to the savestate UI to allow direct access to multiple save slots via keyboard shortcuts, and (2) the addition of support for the Janggun (Janggun-ui Adeul) cartridge mapper, including CRC32-based auto-detection, bank switching, and bit-reversal logic. Several other mappers and heuristics are updated to defer to the new Janggun mapper when it is active.

**Savestate UI improvements:**

- Added support for loading and saving to four distinct save slots using F1–F4 and Alt+F1–F4 keyboard shortcuts, respectively, with direct slot selection on keypress. [[1]](diffhunk://#diff-eaabbea4cf4b1be7bc68a919403ead3ff4d74f1b40dafe0edaeae069e084e5dfL22-R24) [[2]](diffhunk://#diff-eaabbea4cf4b1be7bc68a919403ead3ff4d74f1b40dafe0edaeae069e084e5dfR58) [[3]](diffhunk://#diff-eaabbea4cf4b1be7bc68a919403ead3ff4d74f1b40dafe0edaeae069e084e5dfL73-R109) [[4]](diffhunk://#diff-eaabbea4cf4b1be7bc68a919403ead3ff4d74f1b40dafe0edaeae069e084e5dfL163-R202)

**Janggun mapper support:**

- Implemented CRC32-based auto-detection for the Janggun mapper, with dedicated signals and registers for bank selection and bit-reversal flags per bank. [[1]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R445-R457) [[2]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1526-R1531)
- Integrated Janggun bank switching and bit-reversal logic into the main memory mapping, including reset and state restore handling, and prioritized the mapper over other heuristics and mappers when active. [[1]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1082-R1088) [[2]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1078-R1100) [[3]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1214-R1221) [[4]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1242-R1251) [[5]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1274) [[6]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1294-R1301) [[7]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1321-R1330) [[8]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1311-R1405) [[9]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1529-R1650) [[10]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1552-R1661) [[11]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R1678-R1693)
- Updated all other mapper heuristics (Castle, Nemesis, Wonder Kid, Linear, Sega Locked, Dahjee A) to be suppressed when the Janggun mapper is detected. [[1]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1448-R1550) [[2]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1466-R1562) [[3]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1477-R1573) [[4]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1486-R1582)

**Other improvements and fixes:**

- Improved Zemina opcode scan logic for static mapper detection. [[1]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1786-R1911) [[2]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19L1824-R1950)
- Updated VDP savestate register packing to include `bg_scroll_x_latched` and clarified bit layout.