### PR TITLE
Add CPU-visible VCounter and fix sprite X wrap issue

### DIFF
--- a/SMS.sv
+++ b/SMS.sv
@@ -1030,6 +1030,7 @@ system #(63) system
 	.smode_M1(smode_M1),
 	.smode_M2(smode_M2),
 	.smode_M3(smode_M3),
+	.smode_M4(smode_M4),
 	.ysj_quirk(ysj_quirk),
 	.pal(pal),
 	.region(status[10]),
@@ -1431,7 +1432,7 @@ wire [8:0] y;
 wire [7:0] vcounter_cpu;
 wire [11:0] color;
 wire mask_column;
-wire smode_M1, smode_M2, smode_M3;
+wire smode_M1, smode_M2, smode_M3, smode_M4;
 wire pal = status[2];
 wire border = status[13] & ~gg;
 wire ggres = ~status[39] & gg;
@@ -1449,6 +1450,7 @@ video video
 	.smode_M1(smode_M1),
 	.smode_M2(smode_M2),
 	.smode_M3(smode_M3),
+	.smode_M4(smode_M4),
 	.video_state_out(ss_video_state_out),
 	.video_state_in(ss_video_state_in),
 	.video_state_set(ss_video_state_set),

--- a/SMS.sv
+++ b/SMS.sv
@@ -1022,6 +1022,7 @@ system #(63) system
 
 	.x(x),
 	.y(y),
+	.vcounter_cpu(vcounter_cpu),
 	.color(color),
 	.palettemode(sg_palette),
 	.mask_column(mask_column),
@@ -1427,6 +1428,7 @@ assign AUDIO_R=audio_r;
 
 wire [8:0] x;
 wire [8:0] y;
+wire [7:0] vcounter_cpu;
 wire [11:0] color;
 wire mask_column;
 wire smode_M1, smode_M2, smode_M3;
@@ -1449,9 +1451,10 @@ video video
 	.smode_M3(smode_M3),
 	.video_state_out(ss_video_state_out),
 	.video_state_in(ss_video_state_in),
-	.video_state_set(1'b0),
+	.video_state_set(ss_video_state_set),
 	.x(x),
 	.y(y),
+	.vcounter_cpu(vcounter_cpu),
 	.hsync(HS),
 	.vsync(VS),
 	.hblank(HBlank),

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -92,6 +92,7 @@ entity system is
 
 		x:				in	 STD_LOGIC_VECTOR(8 downto 0);
 		y:				in	 STD_LOGIC_VECTOR(8 downto 0);
+		vcounter_cpu:	in	 STD_LOGIC_VECTOR(7 downto 0);
 		color:		out STD_LOGIC_VECTOR(11 downto 0);
 		palettemode:	in	STD_LOGIC;
 		mask_column:out STD_LOGIC;
@@ -573,6 +574,7 @@ begin
 		D_out		=> vdp_D_out,
 		x			=> x,
 		y			=> y,
+		vcounter_cpu=> vcounter_cpu,
 		color		=> vdp_color,
 		palettemode	=> palettemode,
 --		y1       => vdp_y1,
@@ -624,6 +626,7 @@ begin
 		D_out		=> vdp2_D_out,
 		x			=> x,
 		y			=> y,
+		vcounter_cpu=> vcounter_cpu,
 		color		=> vdp2_color,
 		palettemode	=> palettemode,
 		y1       => vdp2_y1,

--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -100,6 +100,7 @@ entity system is
 		smode_M1:		out STD_LOGIC;
 		smode_M2:		out STD_LOGIC;
 		smode_M3:		out STD_LOGIC;
+		smode_M4:		out STD_LOGIC;
 		ysj_quirk:		in	STD_LOGIC;
 		pal:				in STD_LOGIC;
 		region:			in	STD_LOGIC;
@@ -577,13 +578,14 @@ begin
 		vcounter_cpu=> vcounter_cpu,
 		color		=> vdp_color,
 		palettemode	=> palettemode,
---		y1       => vdp_y1,
-		smode_M1  => smode_M1,
-		smode_M2  => smode_M2,
-		smode_M3  => smode_M3,
-		ysj_quirk	=> ysj_quirk,
+		y1			=> open,
 		mask_column => mask_column,
 		black_column => black_column,
+		smode_M1	=> smode_M1,
+		smode_M2	=> smode_M2,
+		smode_M3	=> smode_M3,
+		smode_M4	=> smode_M4,
+		ysj_quirk	=> ysj_quirk,
 		reset_n  => RESET_n,
 		ss_regs_out => vdp_regs_out,
 		ss_regs_in  => vdp_regs_in,
@@ -629,13 +631,14 @@ begin
 		vcounter_cpu=> vcounter_cpu,
 		color		=> vdp2_color,
 		palettemode	=> palettemode,
-		y1       => vdp2_y1,
---		smode_M1  => smode2_M1,
---		smode_M2  => smode2_M2,
---		smode_M3  => smode2_M3,
-		ysj_quirk	=> ysj_quirk,
---		mask_column => mask2_column,
+		y1			=> vdp2_y1,
+		mask_column => open,
 		black_column => black_column,
+		smode_M1	=> open,
+		smode_M2	=> open,
+		smode_M3	=> open,
+		smode_M4	=> open,
+		ysj_quirk	=> ysj_quirk,
 		reset_n  => RESET_n,
 		ss_regs_out => vdp2_regs_out_i,
 		ss_regs_in  => vdp2_regs_in,

--- a/rtl/vdp.vhd
+++ b/rtl/vdp.vhd
@@ -27,6 +27,7 @@ entity vdp is
 		D_out:			out STD_LOGIC_VECTOR (7 downto 0);
 		x:					in  STD_LOGIC_VECTOR (8 downto 0);
 		y:					in  STD_LOGIC_VECTOR (8 downto 0);
+		vcounter_cpu:		in  STD_LOGIC_VECTOR (7 downto 0);
 		color:			out STD_LOGIC_VECTOR (11 downto 0);
 		palettemode:	in STD_LOGIC;
 		y1:            out std_logic;
@@ -507,7 +508,7 @@ begin
 				elsif old_RD_n = '1' and RD_n='0' then
 					case A(7 downto 6)&A(0) is
 					when "010" => -- VCounter
-						D_out <= y(7 downto 0);
+						D_out <= vcounter_cpu;
 					when "011" => -- HCounter
 						D_out <= latched_x;
 					when "100" => -- Data port

--- a/rtl/vdp_sprite_shifter.vhd
+++ b/rtl/vdp_sprite_shifter.vhd
@@ -42,14 +42,13 @@ begin
 				shift3 <= (others => '0');
 				wideclock <= false;
 			elsif ce_pix = '1' then
-				-- spr_x=0xFF is the wrapped value produced when the VDP sprite X
-				-- register is 0 (the scanner stores VDP_X-1). Treat it as the
-				-- off-screen predecessor of X=0 instead of allowing it to match
-				-- the right edge through the 8-bit coordinate wrap.
-				if ((spr_x=x and ((load and (m4 or spr_d3(7)='0')) or 
-									 (x224 and spr_d3(7)='1'))) and spr_x/=x"FF")
-					or (spr_x=x"FF" and x=x"00" and load)
-					or (spr_x=x+8 and x248 and spr_x/=x"FF") then
+				-- In shifted mode, spr_x=x+8 is an 8-bit comparison.
+				-- spr_x=0xFF corresponds to a sprite with VDP X=0, which
+				-- should be completely off-screen after the 8-pixel shift.
+				-- Do not let the 8-bit comparison wrap it onto the right edge.
+				if (spr_x=x and ((load and (m4 or spr_d3(7)='0')) or 
+									 (x224 and spr_d3(7)='1'))) or 
+					((spr_x=x+8 and x248) and spr_x/=x"FF") then
 					shift0 <= spr_d0;
 					shift1 <= spr_d1;
 					shift2 <= spr_d2;

--- a/rtl/video.vhd
+++ b/rtl/video.vhd
@@ -23,6 +23,7 @@ entity video is
 		
 		x: 				out std_logic_vector(8 downto 0);
 		y:					out std_logic_vector(8 downto 0);
+		vcounter_cpu:	out std_logic_vector(7 downto 0);
 		hsync:			out std_logic;
 		vsync:			out std_logic;
 		hblank:			out std_logic;
@@ -33,6 +34,11 @@ architecture Behavioral of video is
 
 	signal hcount:			std_logic_vector(8 downto 0) := (others => '0');
 	signal vcount:			std_logic_vector(8 downto 0) := (others => '0');
+	
+	-- CPU-visible VCounter advances two pixel ticks before vcount/y updates
+	-- at hcount=487. VDPTEST accepts hcount=484/485 and rejects 486.
+	constant VCOUNT_CPU_UPDATE_HCOUNT : integer := 485;
+	signal vcounter_cpu_reg : std_logic_vector(8 downto 0) := (others => '0');
 	
 	signal hsync_reg:		std_logic := '0';
 	signal vsync_reg:		std_logic := '0';
@@ -51,7 +57,111 @@ begin
 				vcount <= video_state_in(12 downto 4);
 				hsync_reg <= video_state_in(3);
 				vsync_reg <= video_state_in(2);
+				
+				-- Reconstruct CPU VCounter based on whether restored position is in early transition window (486..487)
+				if (video_state_in(21 downto 13) = conv_std_logic_vector(486, 9) or
+				    video_state_in(21 downto 13) = conv_std_logic_vector(487, 9)) then
+					if pal = '1' then
+						if smode_M1 = '1' and smode_M2 = '1' then
+							if video_state_in(12 downto 4) = 258 then
+								vcounter_cpu_reg <= conv_std_logic_vector(458, 9);
+							else
+								vcounter_cpu_reg <= video_state_in(12 downto 4) + 1;
+							end if;
+						elsif smode_M3 = '1' and smode_M2 = '1' then
+							if video_state_in(12 downto 4) = 266 then
+								vcounter_cpu_reg <= conv_std_logic_vector(482, 9);
+							else
+								vcounter_cpu_reg <= video_state_in(12 downto 4) + 1;
+							end if;
+						else
+							if video_state_in(12 downto 4) = 242 then
+								vcounter_cpu_reg <= conv_std_logic_vector(442, 9);
+							else
+								vcounter_cpu_reg <= video_state_in(12 downto 4) + 1;
+							end if;
+						end if;
+					else
+						if smode_M1 = '1' and smode_M2 = '1' then
+							if video_state_in(12 downto 4) = 234 then
+								vcounter_cpu_reg <= conv_std_logic_vector(485, 9);
+							else
+								vcounter_cpu_reg <= video_state_in(12 downto 4) + 1;
+							end if;
+						elsif smode_M3 = '1' and smode_M2 = '1' then
+							if video_state_in(12 downto 4) = 261 then
+								vcounter_cpu_reg <= (others => '0');
+							else
+								vcounter_cpu_reg <= video_state_in(12 downto 4) + 1;
+							end if;
+						else
+							if video_state_in(12 downto 4) = 218 then
+								vcounter_cpu_reg <= conv_std_logic_vector(469, 9);
+							else
+								vcounter_cpu_reg <= video_state_in(12 downto 4) + 1;
+							end if;
+						end if;
+					end if;
+				else
+					vcounter_cpu_reg <= video_state_in(12 downto 4);
+				end if;
 			elsif ce_pix = '1' then
+				-- CPU-visible VCounter changes before the internal line counter.
+				if hcount = conv_std_logic_vector(VCOUNT_CPU_UPDATE_HCOUNT, 9) then
+					if pal = '1' then
+						if smode_M1 = '1' and smode_M2 = '1' then
+							-- PAL 224-line mode
+							if vcount = 258 then
+								vcounter_cpu_reg <= conv_std_logic_vector(458, 9);
+							else
+								vcounter_cpu_reg <= vcount + 1;
+							end if;
+
+						elsif smode_M3 = '1' and smode_M2 = '1' then
+							-- PAL 240-line mode
+							if vcount = 266 then
+								vcounter_cpu_reg <= conv_std_logic_vector(482, 9);
+							else
+								vcounter_cpu_reg <= vcount + 1;
+							end if;
+
+						else
+							-- PAL 192-line mode
+							if vcount = 242 then
+								vcounter_cpu_reg <= conv_std_logic_vector(442, 9);
+							else
+								vcounter_cpu_reg <= vcount + 1;
+							end if;
+						end if;
+
+					else
+						if smode_M1 = '1' and smode_M2 = '1' then
+							-- NTSC 224-line mode
+							if vcount = 234 then
+								vcounter_cpu_reg <= conv_std_logic_vector(485, 9);
+							else
+								vcounter_cpu_reg <= vcount + 1;
+							end if;
+
+						elsif smode_M3 = '1' and smode_M2 = '1' then
+							-- NTSC 240-line mode
+							if vcount = 261 then
+								vcounter_cpu_reg <= (others => '0');
+							else
+								vcounter_cpu_reg <= vcount + 1;
+							end if;
+
+						else
+							-- NTSC 192-line mode
+							if vcount = 218 then
+								vcounter_cpu_reg <= conv_std_logic_vector(469, 9);
+							else
+								vcounter_cpu_reg <= vcount + 1;
+							end if;
+						end if;
+					end if;
+				end if;
+
 				if hcount=487	then
 					vcount <= vcount + 1;
 					if pal = '1' then
@@ -130,6 +240,7 @@ begin
 
 	x	<= hcount;
 	y	<= vcount;
+	vcounter_cpu <= vcounter_cpu_reg(7 downto 0);
 	hsync <= hsync_reg;
 	vsync <= vsync_reg;
 	hblank <= hblank_reg;


### PR DESCRIPTION
This PR:
1) Fixes the "Vcounter chg time" test in SMS VDP Test, fixing https://github.com/MiSTer-devel/SMS_MiSTer/issues/112 . Now the SMS core finally passes through all the SMS VDP tests.
2) Fixes a regression glitch I introduced in Alex Kidd in Miracle World (small "i" letter appearing in the upper left corner of the title screen) when fixing the Great Basketball title screen glitch.

This pull request introduces significant improvements to the VDP (Video Display Processor) emulation, specifically focusing on the CPU-visible vertical counter (`VCounter`) timing. The changes ensure more accurate emulation of hardware behavior, particularly for software that depends on precise `VCounter` transitions, and improve compatibility with test suites like VDPTEST.

**Key improvements include:**

### VDP VCounter Timing Accuracy

* Implemented a new `vcounter_cpu` signal in the `video` module, which advances two pixel ticks before the internal line counter, closely matching real hardware timing. This signal is now passed through the system and used for CPU VCounter reads, ensuring correct behavior in edge cases and compatibility with VDPTEST. [[1]](diffhunk://#diff-caf93c3ea1f572db7ea01df282b7e7b9c1ed06c17ff318346ecd9dbe2dec837dR26) [[2]](diffhunk://#diff-caf93c3ea1f572db7ea01df282b7e7b9c1ed06c17ff318346ecd9dbe2dec837dR38-R42) [[3]](diffhunk://#diff-caf93c3ea1f572db7ea01df282b7e7b9c1ed06c17ff318346ecd9dbe2dec837dR60-R164) [[4]](diffhunk://#diff-caf93c3ea1f572db7ea01df282b7e7b9c1ed06c17ff318346ecd9dbe2dec837dR243) [[5]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R95-R103) [[6]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R578-L584) [[7]](diffhunk://#diff-0f35776bc111cb2a2b0c82c489f8a6312266693f92eb9d3e5da6215b85d78d19R631-R641) [[8]](diffhunk://#diff-6a8750cd756db5f71b2a778664aab245956255fa4a88ee9f2266fa8d8edcbc59R30) [[9]](diffhunk://#diff-6a8750cd756db5f71b2a778664aab245956255fa4a88ee9f2266fa8d8edcbc59L510-R511) [[10]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eR1025-R1033) [[11]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eR1432-R1435) [[12]](diffhunk://#diff-611f67d650ae8753f9f84d55af3e77cf4d1eb36c99074ed24b0de36e7d29d69eR1453-R1459)

### Sprite Shifter Logic Refinement

* Refactored the sprite shifter logic in `vdp_sprite_shifter.vhd` to prevent off-screen sprites (with `spr_x=0xFF`) from incorrectly wrapping around to the right edge in shifted mode, improving sprite rendering accuracy.

These changes collectively improve the accuracy and compatibility of the VDP emulation, especially in edge cases relied upon by test suites and some games.