### PR TITLE
Limit PSG disable to non-Game Gear mode

### DIFF
--- a/rtl/system.vhd
+++ b/rtl/system.vhd
@@ -725,7 +725,7 @@ FM_gated <= (others=>'0') when fm_ena='0' or det_D(0)='0' else  -- All zero if F
 				FM_out(FM_out'high-1 downto 0) when FM_sign=FM_adj else -- Pass through
 				(FM_gated'high=>FM_sign,others=>FM_adj); -- Clamp
 
-PSG_disable <= '1' when (systeme='0' and fm_ena='1' and (not det_D(1)=det_D(0))) else '0';
+PSG_disable <= '1' when (systeme='0' and gg='0' and fm_ena='1' and (not det_D(1)=det_D(0))) else '0';
 				 
 mix_inL <= (others=>'0') when psg_enables(0)='1' or PSG_disable='1' else (PSG_outL(10) & PSG_outL & '0');
 mix_inR <= (others=>'0') when psg_enables(0)='1' or PSG_disable='1' else (PSG_outR(10) & PSG_outR & '0');


### PR DESCRIPTION
Fix the no sound issue in two Game Gear games, reported in issue [#156](https://github.com/MiSTer-devel/SMS_MiSTer/issues/156) :
- Taisen Mahjong HaoPai (Japan)
- Taisen Mahjong HaoPai 2 (Japan)